### PR TITLE
feat: add garbage collection backend endpoints

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -26,6 +26,8 @@ import { mondayWorkspaceRoutes } from './modules/imports/monday/monday-workspace
 import { definitionsRoutes } from './modules/definitions/index.js';
 import { runnerRoutes } from './modules/runner/runner.routes.js';
 import { intakeRoutes, intakePublicRoutes } from './modules/intake/intake.routes.js';
+import { exportsRoutes } from './modules/exports/exports.routes.js';
+import { gcRoutes } from './modules/gc/gc.routes.js';
 import authPlugin from './plugins/auth.js';
 import { errorHandler, notFoundHandler } from './utils/errorHandler.js';
 import { logger } from './utils/logger.js';
@@ -107,6 +109,12 @@ export async function buildApp(): Promise<FastifyInstance> {
 
   // Runner proxy to AutoHelper
   await fastify.register(runnerRoutes, { prefix: '/api' });
+
+  // Export sessions - export workflow
+  await fastify.register(exportsRoutes, { prefix: '/api/exports' });
+
+  // Garbage collection stats and monitoring
+  await fastify.register(gcRoutes, { prefix: '/api/gc' });
 
   // Intake forms (admin + public routes)
   await fastify.register(intakeRoutes, { prefix: '/api/intake' });

--- a/backend/src/modules/gc/gc.routes.ts
+++ b/backend/src/modules/gc/gc.routes.ts
@@ -1,0 +1,80 @@
+/**
+ * Garbage Collection Routes
+ *
+ * API endpoints for garbage collection monitoring and stats:
+ * - GET /stats - Get stale session counts and oldest ages
+ */
+
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+
+// ============================================================================
+// SCHEMAS
+// ============================================================================
+
+const StatsQuerySchema = z.object({
+    retention_days: z.coerce.number().int().positive().default(7),
+});
+
+// ============================================================================
+// ROUTES
+// ============================================================================
+
+export async function gcRoutes(app: FastifyInstance) {
+    /**
+     * Get garbage collection stats
+     * Returns counts and oldest ages of stale sessions for monitoring
+     */
+    app.get('/stats', async (request, reply) => {
+        const { retention_days } = StatsQuerySchema.parse(request.query);
+
+        const { db } = await import('../../db/client.js');
+
+        // Calculate cutoff date
+        const cutoffDate = new Date();
+        cutoffDate.setDate(cutoffDate.getDate() - retention_days);
+
+        // Get import session stats
+        const importStats = await db
+            .selectFrom('import_sessions')
+            .select(({ fn }) => [
+                fn.count<number>('id').as('stale_count'),
+                fn.min('created_at').as('oldest_created_at'),
+            ])
+            .where('created_at', '<', cutoffDate)
+            .executeTakeFirst();
+
+        // Get export session stats
+        const exportStats = await db
+            .selectFrom('export_sessions')
+            .select(({ fn }) => [
+                fn.count<number>('id').as('stale_count'),
+                fn.min('created_at').as('oldest_created_at'),
+            ])
+            .where('created_at', '<', cutoffDate)
+            .executeTakeFirst();
+
+        // Calculate oldest age in days
+        const now = new Date();
+        const importOldestAge = importStats?.oldest_created_at
+            ? Math.floor((now.getTime() - new Date(importStats.oldest_created_at).getTime()) / (1000 * 60 * 60 * 24))
+            : 0;
+        const exportOldestAge = exportStats?.oldest_created_at
+            ? Math.floor((now.getTime() - new Date(exportStats.oldest_created_at).getTime()) / (1000 * 60 * 60 * 24))
+            : 0;
+
+        return reply.send({
+            retention_days,
+            import_sessions: {
+                stale_count: Number(importStats?.stale_count ?? 0),
+                oldest_age_days: importOldestAge,
+            },
+            export_sessions: {
+                stale_count: Number(exportStats?.stale_count ?? 0),
+                oldest_age_days: exportOldestAge,
+            },
+        });
+    });
+}
+
+export default gcRoutes;

--- a/backend/src/modules/gc/index.ts
+++ b/backend/src/modules/gc/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Garbage Collection module exports
+ */
+
+export { gcRoutes } from './gc.routes.js';


### PR DESCRIPTION
## **User description**
## Summary
- Add `DELETE /api/imports/sessions/stale` endpoint to clean up old import sessions
- Add `DELETE /api/exports/sessions/stale` endpoint to clean up old export sessions  
- Create new `gc` module with `GET /api/gc/stats` for monitoring stale session counts
- Register exports and gc routes in app.ts

All endpoints support configurable retention period via `older_than_days` query parameter (default: 7 days).

## Part of GC Service Implementation
This is Phase 1 of the garbage collection service implementation. Subsequent PRs will add:
- AutoHelper GC module with file cleanup tasks
- API cleanup tasks using these new endpoints
- APScheduler integration for automated cleanup

## Test plan
- [ ] Verify `DELETE /api/imports/sessions/stale` deletes old import sessions
- [ ] Verify `DELETE /api/exports/sessions/stale` deletes old export sessions
- [ ] Verify `GET /api/gc/stats` returns correct stale counts
- [ ] Verify cascade deletes remove related plans/executions

Generated with [Claude Code](https://claude.ai/claude-code)


___

## **CodeAnt-AI Description**
Add API endpoints to monitor and remove stale import/export sessions

### What Changed
- New GET /api/gc/stats returns stale counts and oldest age (in days) for import and export sessions; accepts retention_days (default 7)
- New DELETE /api/imports/sessions/stale removes import sessions older than older_than_days (default 7) and returns deleted_count plus deleted session IDs; related plans/executions are removed via cascade
- New DELETE /api/exports/sessions/stale removes export sessions older than older_than_days (default 7) and returns deleted_count plus deleted session IDs
- Registered export and GC routes so the new endpoints are available under /api/exports and /api/gc

### Impact
`✅ Clearer stale session counts for monitoring`
`✅ Fewer stale import/export sessions after manual cleanup`
`✅ Simpler manual cleanup via API (returns which sessions were deleted)`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
