### PR TITLE
feat: add garbage collection module to AutoHelper

### DIFF
--- a/apps/autohelper/autohelper/config/settings.py
+++ b/apps/autohelper/autohelper/config/settings.py
@@ -74,6 +74,14 @@ class Settings(BaseSettings):
     sharepoint_client_id: str | None = None
     sharepoint_client_secret: str | None = None
 
+    # Garbage Collection Settings
+    gc_enabled: bool = True  # Enable/disable GC scheduler
+    gc_schedule_hours: int = Field(default=24, ge=1)  # Run every N hours (min: 1)
+    gc_retention_days: int = Field(default=7, ge=1)  # Retain files/sessions N days (min: 1)
+    gc_rtf_temp_path: str | None = None  # Custom RTF temp path (default: system temp)
+    gc_cleanup_orphaned_manifests: bool = False  # Disabled by default (risky)
+    gc_cleanup_mail_ingest: bool = True  # Clean up processed mail files
+
     def get_allowed_roots(self) -> list[Path]:
         """Parse and validate allowed root paths."""
         return [Path(r).resolve() for r in self.allowed_roots if r]

--- a/apps/autohelper/autohelper/modules/gc/__init__.py
+++ b/apps/autohelper/autohelper/modules/gc/__init__.py
@@ -1,0 +1,6 @@
+"""Garbage Collection module for automated cleanup."""
+
+from .router import router
+from .service import GarbageCollectionService
+
+__all__ = ["router", "GarbageCollectionService"]

--- a/apps/autohelper/autohelper/modules/gc/router.py
+++ b/apps/autohelper/autohelper/modules/gc/router.py
@@ -1,0 +1,117 @@
+"""Garbage Collection module routes."""
+
+from fastapi import APIRouter, BackgroundTasks, HTTPException
+
+from autohelper.config import get_settings
+from autohelper.modules.context.autoart import AutoArtClient
+
+from .scheduler import get_next_run_time, trigger_gc_now
+from .schemas import (
+    GCResultResponse,
+    GCRunResponse,
+    GCStatsResponse,
+    GCStatusResponse,
+    SessionStatsResponse,
+)
+from .service import GarbageCollectionService
+
+router = APIRouter(prefix="/gc", tags=["gc"])
+
+
+@router.get("/status", response_model=GCStatusResponse)
+async def get_gc_status() -> GCStatusResponse:
+    """
+    Get garbage collection status.
+
+    Returns:
+    - Whether GC is enabled
+    - Last run timestamp
+    - Next scheduled run timestamp
+    - Results from last cleanup
+    """
+    settings = get_settings()
+    service = GarbageCollectionService()
+
+    last_result = None
+    if service.last_result:
+        r = service.last_result
+        last_result = GCResultResponse(
+            started_at=r.started_at,
+            completed_at=r.completed_at,
+            status=r.status,
+            rtf_files_deleted=r.rtf_files_deleted,
+            rtf_bytes_freed=r.rtf_bytes_freed,
+            manifests_cleaned=r.manifests_cleaned,
+            mail_files_deleted=r.mail_files_deleted,
+            import_sessions_deleted=r.import_sessions_deleted,
+            export_sessions_deleted=r.export_sessions_deleted,
+            errors=r.errors,
+        )
+
+    return GCStatusResponse(
+        enabled=settings.gc_enabled,
+        last_run=service.last_run,
+        next_run=get_next_run_time(),
+        last_result=last_result,
+    )
+
+
+@router.post("/run", response_model=GCRunResponse)
+async def run_gc_now(background_tasks: BackgroundTasks) -> GCRunResponse:
+    """
+    Trigger an immediate garbage collection run.
+
+    This runs in the background and returns immediately.
+    Check /gc/status for results.
+    """
+    service = GarbageCollectionService()
+
+    if service.is_running:
+        raise HTTPException(
+            status_code=409,
+            detail="Garbage collection is already running",
+        )
+
+    # Run in background
+    background_tasks.add_task(trigger_gc_now)
+
+    return GCRunResponse(
+        status="started",
+        message="Garbage collection started in background",
+    )
+
+
+@router.get("/stats", response_model=GCStatsResponse)
+async def get_gc_stats() -> GCStatsResponse:
+    """
+    Get garbage collection stats from backend.
+
+    Returns stale session counts and oldest ages for monitoring.
+    Proxies to backend /api/gc/stats endpoint.
+    """
+    settings = get_settings()
+    client = AutoArtClient(
+        api_url=settings.autoart_api_url,
+        api_key=settings.autoart_api_key,
+        session_id=settings.autoart_session_id,
+    )
+
+    stats = client.get_gc_stats(retention_days=settings.gc_retention_days)
+
+    if stats is None:
+        raise HTTPException(
+            status_code=502,
+            detail="Failed to fetch GC stats from backend",
+        )
+
+    return GCStatsResponse(
+        retention_days=stats.get("retention_days", settings.gc_retention_days),
+        import_sessions=SessionStatsResponse(
+            stale_count=stats.get("import_sessions", {}).get("stale_count", 0),
+            oldest_age_days=stats.get("import_sessions", {}).get("oldest_age_days", 0),
+        ),
+        export_sessions=SessionStatsResponse(
+            stale_count=stats.get("export_sessions", {}).get("stale_count", 0),
+            oldest_age_days=stats.get("export_sessions", {}).get("oldest_age_days", 0),
+        ),
+    )

--- a/apps/autohelper/autohelper/modules/gc/scheduler.py
+++ b/apps/autohelper/autohelper/modules/gc/scheduler.py
@@ -1,0 +1,120 @@
+"""Garbage Collection scheduler using APScheduler."""
+
+import logging
+from datetime import datetime, timedelta
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+
+from autohelper.config import get_settings
+
+from .service import GarbageCollectionService
+
+logger = logging.getLogger(__name__)
+
+# Global scheduler instance
+_scheduler: AsyncIOScheduler | None = None
+
+
+def get_scheduler() -> AsyncIOScheduler | None:
+    """Get the global scheduler instance."""
+    return _scheduler
+
+
+def get_next_run_time() -> datetime | None:
+    """Get the next scheduled GC run time."""
+    if _scheduler is None:
+        return None
+
+    job = _scheduler.get_job("garbage_collection")
+    if job is None:
+        return None
+
+    next_run = job.next_run_time
+    if next_run is None:
+        return None
+    # Cast to datetime since APScheduler returns Any
+    return datetime.fromisoformat(str(next_run)) if not isinstance(next_run, datetime) else next_run
+
+
+def start_gc_scheduler(gc_service: GarbageCollectionService | None = None) -> bool:
+    """
+    Start the garbage collection scheduler.
+
+    Args:
+        gc_service: GC service instance (default: singleton)
+
+    Returns:
+        True if scheduler started, False if disabled
+    """
+    global _scheduler
+
+    settings = get_settings()
+
+    # Check if GC is enabled
+    if not settings.gc_enabled:
+        logger.info("Garbage collection is disabled, scheduler not started")
+        return False
+
+    if gc_service is None:
+        gc_service = GarbageCollectionService()
+
+    # Create scheduler if it doesn't exist
+    if _scheduler is None:
+        _scheduler = AsyncIOScheduler()
+
+    # Remove existing job if any
+    existing_job = _scheduler.get_job("garbage_collection")
+    if existing_job:
+        _scheduler.remove_job("garbage_collection")
+
+    # Add the GC job
+    _scheduler.add_job(
+        gc_service.run_cleanup,
+        IntervalTrigger(hours=settings.gc_schedule_hours),
+        id="garbage_collection",
+        name="Garbage Collection",
+        replace_existing=True,
+        next_run_time=datetime.now() + timedelta(minutes=5),  # First run in 5 minutes
+    )
+
+    # Start the scheduler if not running
+    if not _scheduler.running:
+        _scheduler.start()
+        logger.info(
+            f"GC scheduler started (interval: {settings.gc_schedule_hours}h, "
+            f"retention: {settings.gc_retention_days}d)"
+        )
+    else:
+        logger.info("GC scheduler job updated")
+
+    return True
+
+
+def stop_gc_scheduler() -> None:
+    """Stop the garbage collection scheduler."""
+    global _scheduler
+
+    if _scheduler is not None and _scheduler.running:
+        _scheduler.shutdown(wait=False)
+        logger.info("GC scheduler stopped")
+
+    _scheduler = None
+
+
+def trigger_gc_now() -> bool:
+    """
+    Trigger an immediate GC run outside the schedule.
+
+    Returns:
+        True if triggered, False if already running
+    """
+    gc_service = GarbageCollectionService()
+
+    if gc_service.is_running:
+        logger.warning("GC already running, cannot trigger")
+        return False
+
+    # Run synchronously (for manual trigger)
+    gc_service.run_cleanup()
+    return True

--- a/apps/autohelper/autohelper/modules/gc/schemas.py
+++ b/apps/autohelper/autohelper/modules/gc/schemas.py
@@ -1,0 +1,55 @@
+"""Garbage Collection module schemas."""
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class GCStatusResponse(BaseModel):
+    """Response for GET /gc/status."""
+
+    enabled: bool
+    last_run: datetime | None
+    next_run: datetime | None
+    last_result: "GCResultResponse | None"
+
+
+class GCResultResponse(BaseModel):
+    """Cleanup result summary."""
+
+    started_at: datetime
+    completed_at: datetime | None
+    status: str
+    rtf_files_deleted: int
+    rtf_bytes_freed: int
+    manifests_cleaned: int
+    mail_files_deleted: int
+    import_sessions_deleted: int
+    export_sessions_deleted: int
+    errors: list[str]
+
+
+class GCRunResponse(BaseModel):
+    """Response for POST /gc/run."""
+
+    status: str
+    message: str
+
+
+class GCStatsResponse(BaseModel):
+    """Response for GET /gc/stats (proxied from backend)."""
+
+    retention_days: int
+    import_sessions: "SessionStatsResponse"
+    export_sessions: "SessionStatsResponse"
+
+
+class SessionStatsResponse(BaseModel):
+    """Stats for a session type."""
+
+    stale_count: int
+    oldest_age_days: int
+
+
+# Update forward references
+GCStatusResponse.model_rebuild()

--- a/apps/autohelper/autohelper/modules/gc/service.py
+++ b/apps/autohelper/autohelper/modules/gc/service.py
@@ -1,0 +1,223 @@
+"""Garbage Collection service - orchestrates cleanup tasks."""
+
+import logging
+import threading
+from datetime import UTC, datetime
+
+from autohelper.config import Settings, get_settings
+from autohelper.modules.context.autoart import AutoArtClient
+
+from .tasks import (
+    cleanup_export_sessions,
+    cleanup_import_sessions,
+    cleanup_mail_ingest,
+    cleanup_orphaned_manifests,
+    cleanup_rtf_exports,
+)
+from .types import CleanupResult, GCConfig
+
+logger = logging.getLogger(__name__)
+
+
+class GarbageCollectionService:
+    """
+    Service for orchestrating garbage collection tasks.
+
+    This service manages:
+    - RTF export cleanup (temp files)
+    - Orphaned manifest cleanup (optional)
+    - Mail ingest cleanup
+    - Backend session cleanup (import/export)
+
+    Usage:
+        gc_service = GarbageCollectionService()
+        result = gc_service.run_cleanup()
+    """
+
+    _instance: "GarbageCollectionService | None" = None
+    _lock = threading.Lock()  # Class lock for singleton creation
+    _initialized: bool = False
+
+    def __new__(cls) -> "GarbageCollectionService":
+        """Singleton pattern with thread safety."""
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = super().__new__(cls)
+                cls._instance._initialized = False
+            return cls._instance
+
+    def __init__(self, settings: Settings | None = None) -> None:
+        if self._initialized:
+            return
+
+        self._settings = settings or get_settings()
+        self._config = self._load_config()
+        self._last_result: CleanupResult | None = None
+        self._last_run: datetime | None = None
+        self._running = False
+        self._run_lock = threading.Lock()  # Instance lock for run state
+        self._client: AutoArtClient | None = None
+        self._initialized = True
+
+    def _load_config(self) -> GCConfig:
+        """Load GC config from settings."""
+        return GCConfig(
+            enabled=getattr(self._settings, "gc_enabled", True),
+            schedule_hours=getattr(self._settings, "gc_schedule_hours", 24),
+            retention_days=getattr(self._settings, "gc_retention_days", 7),
+            rtf_temp_path=getattr(self._settings, "gc_rtf_temp_path", None),
+            cleanup_orphaned_manifests=getattr(
+                self._settings, "gc_cleanup_orphaned_manifests", False
+            ),
+            cleanup_mail_ingest=getattr(self._settings, "gc_cleanup_mail_ingest", True),
+        )
+
+    def _get_client(self) -> AutoArtClient:
+        """Get or create AutoArt client."""
+        if self._client is None:
+            self._client = AutoArtClient(
+                api_url=self._settings.autoart_api_url,
+                api_key=self._settings.autoart_api_key,
+                session_id=self._settings.autoart_session_id,
+            )
+        return self._client
+
+    @property
+    def enabled(self) -> bool:
+        """Check if GC is enabled."""
+        return self._config.enabled
+
+    @property
+    def last_run(self) -> datetime | None:
+        """Get the last run timestamp."""
+        return self._last_run
+
+    @property
+    def last_result(self) -> CleanupResult | None:
+        """Get the last cleanup result."""
+        return self._last_result
+
+    @property
+    def is_running(self) -> bool:
+        """Check if cleanup is currently running."""
+        with self._run_lock:
+            return self._running
+
+    def run_cleanup(self) -> CleanupResult:
+        """
+        Run all configured cleanup tasks.
+
+        Returns:
+            CleanupResult with aggregated stats from all tasks
+        """
+        # Use lock to check and set _running atomically
+        with self._run_lock:
+            if self._running:
+                logger.warning("Cleanup already running, skipping")
+                return CleanupResult(
+                    started_at=datetime.now(UTC),
+                    status="failed",
+                    errors=["Cleanup already running"],
+                )
+            self._running = True
+
+        result = CleanupResult(started_at=datetime.now(UTC))
+
+        try:
+            logger.info("Starting garbage collection run")
+
+            # 1. RTF Export Cleanup
+            try:
+                rtf_result = cleanup_rtf_exports(
+                    retention_days=self._config.retention_days,
+                    temp_path=self._config.rtf_temp_path,
+                )
+                result.merge_file_result(rtf_result)
+            except Exception as e:
+                error_msg = f"RTF cleanup failed: {e}"
+                logger.error(error_msg)
+                result.errors.append(error_msg)
+
+            # 2. Orphaned Manifest Cleanup (if enabled)
+            if self._config.cleanup_orphaned_manifests:
+                try:
+                    manifest_result = cleanup_orphaned_manifests(
+                        retention_days=self._config.retention_days,
+                    )
+                    result.merge_file_result(manifest_result)
+                except Exception as e:
+                    error_msg = f"Manifest cleanup failed: {e}"
+                    logger.error(error_msg)
+                    result.errors.append(error_msg)
+
+            # 3. Mail Ingest Cleanup (if enabled)
+            if self._config.cleanup_mail_ingest:
+                try:
+                    mail_result = cleanup_mail_ingest(
+                        retention_days=self._config.retention_days,
+                    )
+                    result.merge_file_result(mail_result)
+                except Exception as e:
+                    error_msg = f"Mail cleanup failed: {e}"
+                    logger.error(error_msg)
+                    result.errors.append(error_msg)
+
+            # 4. Backend Session Cleanup
+            client = self._get_client()
+
+            try:
+                import_result = cleanup_import_sessions(
+                    retention_days=self._config.retention_days,
+                    client=client,
+                )
+                result.merge_api_result(import_result)
+            except Exception as e:
+                error_msg = f"Import session cleanup failed: {e}"
+                logger.error(error_msg)
+                result.errors.append(error_msg)
+
+            try:
+                export_result = cleanup_export_sessions(
+                    retention_days=self._config.retention_days,
+                    client=client,
+                )
+                result.merge_api_result(export_result)
+            except Exception as e:
+                error_msg = f"Export session cleanup failed: {e}"
+                logger.error(error_msg)
+                result.errors.append(error_msg)
+
+            result.status = "completed"
+            result.completed_at = datetime.now(UTC)
+            self._last_result = result
+            self._last_run = result.started_at
+
+            logger.info(
+                f"Garbage collection completed: "
+                f"RTF={result.rtf_files_deleted}, "
+                f"manifests={result.manifests_cleaned}, "
+                f"mail={result.mail_files_deleted}, "
+                f"import_sessions={result.import_sessions_deleted}, "
+                f"export_sessions={result.export_sessions_deleted}"
+            )
+
+        except Exception as e:
+            error_msg = f"Garbage collection run failed: {e}"
+            logger.error(error_msg)
+            result.status = "failed"
+            result.completed_at = datetime.now(UTC)
+            result.errors.append(error_msg)
+            self._last_result = result
+
+        finally:
+            with self._run_lock:
+                self._running = False
+
+        return result
+
+    def reload_config(self) -> None:
+        """Reload configuration from settings."""
+        self._settings = get_settings()
+        self._config = self._load_config()
+        self._client = None  # Reset client to pick up new settings
+        logger.info("GC config reloaded")

--- a/apps/autohelper/autohelper/modules/gc/tasks/__init__.py
+++ b/apps/autohelper/autohelper/modules/gc/tasks/__init__.py
@@ -1,0 +1,12 @@
+"""Garbage collection cleanup tasks."""
+
+from .api_cleanup import cleanup_export_sessions, cleanup_import_sessions
+from .file_cleanup import cleanup_mail_ingest, cleanup_orphaned_manifests, cleanup_rtf_exports
+
+__all__ = [
+    "cleanup_rtf_exports",
+    "cleanup_orphaned_manifests",
+    "cleanup_mail_ingest",
+    "cleanup_import_sessions",
+    "cleanup_export_sessions",
+]

--- a/apps/autohelper/autohelper/modules/gc/tasks/api_cleanup.py
+++ b/apps/autohelper/autohelper/modules/gc/tasks/api_cleanup.py
@@ -1,0 +1,98 @@
+"""API cleanup tasks for garbage collection."""
+
+import logging
+
+from autohelper.config import get_settings
+from autohelper.modules.context.autoart import AutoArtClient
+
+from ..types import APICleanupResult
+
+logger = logging.getLogger(__name__)
+
+
+def cleanup_import_sessions(
+    retention_days: int = 7,
+    client: AutoArtClient | None = None,
+) -> APICleanupResult:
+    """
+    Clean up stale import sessions via backend API.
+
+    Args:
+        retention_days: Number of days to retain sessions
+        client: AutoArtClient instance (default: create from settings)
+
+    Returns:
+        APICleanupResult with deletion stats
+    """
+    result = APICleanupResult(task_name="import_sessions", sessions_deleted=0)
+
+    if client is None:
+        settings = get_settings()
+        client = AutoArtClient(
+            api_url=settings.autoart_api_url,
+            api_key=settings.autoart_api_key,
+            session_id=settings.autoart_session_id,
+        )
+
+    # Check if backend is reachable
+    if not client.test_connection():
+        error_msg = "Backend not reachable, skipping import session cleanup"
+        logger.warning(error_msg)
+        result.errors.append(error_msg)
+        return result
+
+    try:
+        deleted_count, session_ids = client.delete_stale_import_sessions(retention_days)
+        result.sessions_deleted = deleted_count
+        result.session_ids = session_ids
+        logger.info(f"Import session cleanup: deleted {deleted_count} sessions")
+    except Exception as e:
+        error_msg = f"Error cleaning up import sessions: {e}"
+        logger.error(error_msg)
+        result.errors.append(error_msg)
+
+    return result
+
+
+def cleanup_export_sessions(
+    retention_days: int = 7,
+    client: AutoArtClient | None = None,
+) -> APICleanupResult:
+    """
+    Clean up stale export sessions via backend API.
+
+    Args:
+        retention_days: Number of days to retain sessions
+        client: AutoArtClient instance (default: create from settings)
+
+    Returns:
+        APICleanupResult with deletion stats
+    """
+    result = APICleanupResult(task_name="export_sessions", sessions_deleted=0)
+
+    if client is None:
+        settings = get_settings()
+        client = AutoArtClient(
+            api_url=settings.autoart_api_url,
+            api_key=settings.autoart_api_key,
+            session_id=settings.autoart_session_id,
+        )
+
+    # Check if backend is reachable
+    if not client.test_connection():
+        error_msg = "Backend not reachable, skipping export session cleanup"
+        logger.warning(error_msg)
+        result.errors.append(error_msg)
+        return result
+
+    try:
+        deleted_count, session_ids = client.delete_stale_export_sessions(retention_days)
+        result.sessions_deleted = deleted_count
+        result.session_ids = session_ids
+        logger.info(f"Export session cleanup: deleted {deleted_count} sessions")
+    except Exception as e:
+        error_msg = f"Error cleaning up export sessions: {e}"
+        logger.error(error_msg)
+        result.errors.append(error_msg)
+
+    return result

--- a/apps/autohelper/autohelper/modules/gc/tasks/file_cleanup.py
+++ b/apps/autohelper/autohelper/modules/gc/tasks/file_cleanup.py
@@ -1,0 +1,231 @@
+"""File cleanup tasks for garbage collection."""
+
+import logging
+import shutil
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from autohelper.config import get_settings
+
+from ..types import FileCleanupResult
+
+logger = logging.getLogger(__name__)
+
+
+def cleanup_rtf_exports(
+    retention_days: int = 7,
+    temp_path: str | None = None,
+) -> FileCleanupResult:
+    """
+    Clean up old RTF export files from temp directory.
+
+    RTF exports are created with pattern: bfa_todo_*.rtf
+    Files older than retention_days are deleted.
+
+    Args:
+        retention_days: Number of days to retain files
+        temp_path: Custom temp path (default: system temp)
+
+    Returns:
+        FileCleanupResult with deletion stats
+    """
+    result = FileCleanupResult(task_name="rtf_cleanup", files_deleted=0, bytes_freed=0)
+
+    # Use system temp if not specified
+    if temp_path is None:
+        temp_path = tempfile.gettempdir()
+
+    temp_dir = Path(temp_path)
+    if not temp_dir.exists():
+        logger.warning(f"RTF temp path does not exist: {temp_path}")
+        return result
+
+    cutoff_time = datetime.now() - timedelta(days=retention_days)
+    cutoff_timestamp = cutoff_time.timestamp()
+
+    # Find RTF files matching the pattern
+    pattern = "bfa_todo_*.rtf"
+    try:
+        for rtf_file in temp_dir.glob(pattern):
+            try:
+                stat = rtf_file.stat()
+                if stat.st_mtime < cutoff_timestamp:
+                    file_size = stat.st_size
+                    rtf_file.unlink()
+                    result.files_deleted += 1
+                    result.bytes_freed += file_size
+                    logger.debug(f"Deleted stale RTF: {rtf_file.name}")
+            except OSError as e:
+                error_msg = f"Failed to delete {rtf_file}: {e}"
+                logger.warning(error_msg)
+                result.errors.append(error_msg)
+    except Exception as e:
+        error_msg = f"Error scanning RTF files: {e}"
+        logger.error(error_msg)
+        result.errors.append(error_msg)
+
+    logger.info(
+        f"RTF cleanup: deleted {result.files_deleted} files, freed {result.bytes_freed} bytes"
+    )
+    return result
+
+
+def cleanup_orphaned_manifests(
+    retention_days: int = 7,
+    allowed_roots: list[str] | None = None,
+) -> FileCleanupResult:
+    """
+    Clean up orphaned .artcollector manifest directories.
+
+    An orphaned manifest is one where:
+    - The parent directory contains no image/media files
+    - The manifest is older than retention_days
+
+    This is a risky operation and should only be run with explicit user consent.
+
+    Args:
+        retention_days: Number of days to retain manifests
+        allowed_roots: List of root paths to scan (default: from settings)
+
+    Returns:
+        FileCleanupResult with deletion stats
+    """
+    result = FileCleanupResult(task_name="manifest_cleanup", files_deleted=0, bytes_freed=0)
+
+    settings = get_settings()
+    if allowed_roots is None:
+        allowed_roots = settings.allowed_roots
+
+    if not allowed_roots:
+        logger.info("No allowed roots configured, skipping manifest cleanup")
+        return result
+
+    cutoff_time = datetime.now() - timedelta(days=retention_days)
+    cutoff_timestamp = cutoff_time.timestamp()
+
+    # Image/media extensions to check for
+    media_extensions = {
+        ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".webp",
+        ".mp4", ".mov", ".avi", ".mkv", ".mp3", ".wav", ".flac",
+    }
+
+    for root_path in allowed_roots:
+        root = Path(root_path)
+        if not root.exists():
+            continue
+
+        # Find .artcollector directories
+        try:
+            for manifest_dir in root.rglob(".artcollector"):
+                if not manifest_dir.is_dir():
+                    continue
+
+                try:
+                    # Check manifest age
+                    manifest_mtime = manifest_dir.stat().st_mtime
+                    if manifest_mtime >= cutoff_timestamp:
+                        continue  # Not old enough
+
+                    # Check if parent has media files
+                    parent = manifest_dir.parent
+                    has_media = False
+                    for item in parent.iterdir():
+                        if item.is_file() and item.suffix.lower() in media_extensions:
+                            has_media = True
+                            break
+
+                    if not has_media:
+                        # Orphaned manifest - delete it
+                        files = [f for f in manifest_dir.rglob("*") if f.is_file()]
+                        bytes_freed = sum(f.stat().st_size for f in files)
+
+                        try:
+                            shutil.rmtree(manifest_dir)
+                            result.files_deleted += 1
+                            result.bytes_freed += bytes_freed
+                            logger.debug(f"Deleted orphaned manifest: {manifest_dir}")
+                        except OSError as rm_err:
+                            error_msg = f"Failed to remove {manifest_dir}: {rm_err}"
+                            logger.warning(error_msg)
+                            result.errors.append(error_msg)
+
+                except OSError as e:
+                    error_msg = f"Failed to process manifest {manifest_dir}: {e}"
+                    logger.warning(error_msg)
+                    result.errors.append(error_msg)
+
+        except Exception as e:
+            error_msg = f"Error scanning root {root_path}: {e}"
+            logger.error(error_msg)
+            result.errors.append(error_msg)
+
+    logger.info(
+        f"Manifest cleanup: deleted {result.files_deleted} dirs, "
+        f"freed {result.bytes_freed} bytes"
+    )
+    return result
+
+
+def cleanup_mail_ingest(
+    retention_days: int = 7,
+    mail_ingest_path: Path | None = None,
+) -> FileCleanupResult:
+    """
+    Clean up processed mail files from ingest directory.
+
+    Deletes .pst and other processed mail files older than retention_days.
+
+    Args:
+        retention_days: Number of days to retain files
+        mail_ingest_path: Custom ingest path (default: from settings)
+
+    Returns:
+        FileCleanupResult with deletion stats
+    """
+    result = FileCleanupResult(task_name="mail_cleanup", files_deleted=0, bytes_freed=0)
+
+    settings = get_settings()
+    if mail_ingest_path is None:
+        mail_ingest_path = settings.mail_ingest_path
+
+    if not mail_ingest_path.exists():
+        logger.info(f"Mail ingest path does not exist: {mail_ingest_path}")
+        return result
+
+    cutoff_time = datetime.now() - timedelta(days=retention_days)
+    cutoff_timestamp = cutoff_time.timestamp()
+
+    # Mail file extensions to clean up
+    mail_extensions = {".pst", ".ost", ".mbox", ".eml"}
+
+    try:
+        for mail_file in mail_ingest_path.iterdir():
+            if not mail_file.is_file():
+                continue
+
+            if mail_file.suffix.lower() not in mail_extensions:
+                continue
+
+            try:
+                stat = mail_file.stat()
+                if stat.st_mtime < cutoff_timestamp:
+                    file_size = stat.st_size
+                    mail_file.unlink()
+                    result.files_deleted += 1
+                    result.bytes_freed += file_size
+                    logger.debug(f"Deleted stale mail file: {mail_file.name}")
+            except OSError as e:
+                error_msg = f"Failed to delete {mail_file}: {e}"
+                logger.warning(error_msg)
+                result.errors.append(error_msg)
+
+    except Exception as e:
+        error_msg = f"Error scanning mail ingest: {e}"
+        logger.error(error_msg)
+        result.errors.append(error_msg)
+
+    logger.info(
+        f"Mail cleanup: deleted {result.files_deleted} files, freed {result.bytes_freed} bytes"
+    )
+    return result

--- a/apps/autohelper/autohelper/modules/gc/types.py
+++ b/apps/autohelper/autohelper/modules/gc/types.py
@@ -1,0 +1,72 @@
+"""Garbage Collection types and data classes."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Literal
+
+
+@dataclass
+class GCConfig:
+    """Configuration for garbage collection."""
+
+    enabled: bool = True
+    schedule_hours: int = 24  # Run daily
+    retention_days: int = 7
+    rtf_temp_path: str | None = None  # Auto-detect OS temp
+    cleanup_orphaned_manifests: bool = False  # Disabled by default (risky)
+    cleanup_mail_ingest: bool = True
+
+
+@dataclass
+class FileCleanupResult:
+    """Result of a file cleanup task."""
+
+    task_name: str
+    files_deleted: int
+    bytes_freed: int
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class APICleanupResult:
+    """Result of an API cleanup task."""
+
+    task_name: str
+    sessions_deleted: int
+    session_ids: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class CleanupResult:
+    """Aggregated result of all cleanup tasks."""
+
+    started_at: datetime
+    completed_at: datetime | None = None
+    status: Literal["running", "completed", "failed"] = "running"
+    rtf_files_deleted: int = 0
+    rtf_bytes_freed: int = 0
+    manifests_cleaned: int = 0
+    mail_files_deleted: int = 0
+    import_sessions_deleted: int = 0
+    export_sessions_deleted: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    def merge_file_result(self, result: FileCleanupResult) -> None:
+        """Merge a file cleanup result into this aggregate."""
+        if result.task_name == "rtf_cleanup":
+            self.rtf_files_deleted += result.files_deleted
+            self.rtf_bytes_freed += result.bytes_freed
+        elif result.task_name == "manifest_cleanup":
+            self.manifests_cleaned += result.files_deleted
+        elif result.task_name == "mail_cleanup":
+            self.mail_files_deleted += result.files_deleted
+        self.errors.extend(result.errors)
+
+    def merge_api_result(self, result: APICleanupResult) -> None:
+        """Merge an API cleanup result into this aggregate."""
+        if result.task_name == "import_sessions":
+            self.import_sessions_deleted += result.sessions_deleted
+        elif result.task_name == "export_sessions":
+            self.export_sessions_deleted += result.sessions_deleted
+        self.errors.extend(result.errors)

--- a/apps/autohelper/pyproject.toml
+++ b/apps/autohelper/pyproject.toml
@@ -23,6 +23,8 @@ dependencies = [
     "lxml>=5.0.0",
     # HTTP client for AutoArt API (pairing)
     "requests>=2.31.0",
+    # Scheduler for garbage collection
+    "apscheduler>=3.10.0",
     # Windows-specific:
     "pywin32>=306; sys_platform == 'win32'",
 ]


### PR DESCRIPTION
## **User description**
## Summary
Phase 2 of GC service implementation - adds the AutoHelper Python module for garbage collection:

- Create `gc` module structure with types, schemas, service, router
- Add file cleanup tasks (RTF exports, orphaned manifests, mail ingest)
- Add API cleanup tasks (import/export sessions via backend DELETE endpoints)
- Extend `AutoArtClient` with `delete_stale_*` and `get_gc_stats` methods
- Add GC settings to config with validation (`gc_schedule_hours >= 1`, `gc_retention_days >= 1`)
- Add APScheduler integration for scheduled cleanup
- Add thread-safe locking for concurrent run protection
- Register GC router and start scheduler in app lifespan
- Add `apscheduler>=3.10.0` dependency

## Endpoints
- `GET /gc/status` - Get GC status, last run, next scheduled run
- `POST /gc/run` - Trigger immediate cleanup (runs in background)
- `GET /gc/stats` - Proxy to backend GC stats endpoint

## Review Feedback Addressed
- Added validation to GC settings (Field with ge=1)
- Added thread-safe locking for _running flag
- Improved error handling for shutil.rmtree

## Test plan
- [ ] Verify GC scheduler starts on app startup
- [ ] Verify `POST /gc/run` triggers cleanup
- [ ] Verify `GET /gc/status` returns correct state
- [ ] Verify RTF cleanup deletes old temp files
- [ ] Verify API cleanup calls backend DELETE endpoints

Generated with [Claude Code](https://claude.ai/claude-code)


___

## **CodeAnt-AI Description**
**Add scheduled garbage collection with API endpoints and file/session cleanup**

### What Changed
- App now starts a GC scheduler on startup (APScheduler) and stops it on shutdown; scheduler runs cleanup at configured hourly intervals and can be triggered immediately via API.
- New /gc endpoints:
  - GET /gc/status returns enabled state, last run, next scheduled run, and last run summary.
  - POST /gc/run starts a background GC run (409 if already running).
  - GET /gc/stats proxies backend GC stats (stale import/export session counts and ages).
- New configurable GC settings (enabled, schedule hours, retention days, temp path, manifest/mail cleanup toggles) with minimum-value validation and default values.
- File cleanup tasks remove stale RTF temp files and processed mail files; optional cleanup of orphaned manifest directories. Backend cleanup deletes stale import/export sessions via the backend API. GC run aggregation reports counts, bytes freed, and errors; concurrent runs are prevented.

### Impact
`✅ Clears old temporary RTF files automatically`
`✅ Fewer stale import/export sessions retained on backend`
`✅ Ability to manually trigger and monitor GC runs via /gc endpoints`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
