### PR TITLE
refactor: rename action_recipe to action_arrangement in shared schema

### DIFF
--- a/shared/src/schemas/records.ts
+++ b/shared/src/schemas/records.ts
@@ -83,7 +83,7 @@ export const RecordDefinitionSchema = z.object({
   project_id: z.string().uuid().nullable(), // If set, belongs to project's template library
   is_template: z.boolean(),
   is_system: z.boolean(), // System definitions (Task, Subtask, etc.) - cannot be deleted
-  kind: z.enum(['record', 'action_recipe', 'container']).default('record'), // Discriminator for definition types
+  kind: z.enum(['record', 'action_arrangement', 'container']).default('record'), // Discriminator for definition types
   parent_definition_id: z.string().uuid().nullable(), // For hierarchical types (e.g., Subtask under Task)
   clone_excluded: z.boolean(),
   pinned: z.boolean(),


### PR DESCRIPTION
## **User description**
## Summary
- Update `kind` enum in `RecordDefinitionSchema` from `action_recipe` to `action_arrangement`
- First phase of action arrangement refactor

Refs #131

## Test plan
- [x] `pnpm build:shared` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Rename action_recipe kind to action_arrangement in shared record schema

### What Changed
- The record definition schema now recognizes "action_arrangement" instead of "action_recipe" for that kind discriminator
- Default kind value remains "record"; other kinds ("container") unchanged
- Validation and imports that previously used "action_recipe" must use "action_arrangement" going forward

### Impact
`✅ Clearer definition type name`
`✅ Fewer naming confusions when creating or importing action definitions`
`✅ Required updates to any records or templates using the old "action_recipe" kind`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
