### PR TITLE
fix: navigate to imported project after import completes

### DIFF
--- a/frontend/src/workflows/import/wizard/steps/Step6Execute.tsx
+++ b/frontend/src/workflows/import/wizard/steps/Step6Execute.tsx
@@ -89,7 +89,12 @@ export function Step6Execute({ onBack, session, plan }: StepProps) {
 
     const handleFinish = () => {
         // Navigate to the imported project, or fallback to projects list
-        const projectId = executionStats?.createdIds?.project;
+        // createdIds is keyed by container tempId, not literal 'project'
+        const projectContainer = plan?.containers.find((c) => c.type === 'project');
+        const projectId =
+            projectContainer &&
+            executionStats?.createdIds &&
+            executionStats.createdIds[projectContainer.tempId];
         const targetUrl = projectId ? `/projects/${projectId}` : '/projects';
         if (typeof window !== 'undefined' && window.location) {
             window.location.href = targetUrl;


### PR DESCRIPTION
## **User description**
## Summary
- Step6Execute now navigates to `/projects/{id}` using `createdIds.project` from execution stats
- Falls back to `/projects` if no project ID available

Closes #151

## Test plan
- [ ] Run import wizard through all steps
- [ ] Click "Go to Project" button
- [ ] Verify navigation lands on `/projects/{id}` for the imported project

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Navigate to the newly imported project after import completes

### What Changed
- The "Finish" action now sends the user to the specific imported project's page when an imported project ID is available
- If no imported project ID is present, the "Finish" action falls back to opening the projects list
- No user-visible change when session or plan is missing (existing message still shown)

### Impact
`✅ Lands user on imported project`
`✅ Shorter time to access newly imported data`
`✅ Fewer manual searches for imported projects`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
