### PR TITLE
refactor: complete action_recipe to action_arrangement rename

### DIFF
--- a/frontend/src/api/hooks/entities/definitions.ts
+++ b/frontend/src/api/hooks/entities/definitions.ts
@@ -14,7 +14,7 @@ export function useRecordDefinitions() {
 }
 
 export interface DefinitionFilterOptions {
-  definitionKind?: 'record' | 'action_recipe' | 'container';
+  definitionKind?: 'record' | 'action_arrangement' | 'container';
   projectId?: string;
   isTemplate?: boolean;
   isSystem?: boolean;

--- a/frontend/src/pages/ActionsPage.tsx
+++ b/frontend/src/pages/ActionsPage.tsx
@@ -4,10 +4,10 @@
  * Registry view for Action Definitions and Action Instances.
  *
  * Structure:
- * - Definitions tab: Action Definitions (definition_kind='action_recipe')
+ * - Definitions tab: Action Definitions (definition_kind='action_arrangement')
  * - Instances tab: Action instances filtered by selected definition
  *
- * Note: + button opens Composer to create new action recipe.
+ * Note: + button opens Composer to create new action arrangement.
  */
 
 import { Zap } from 'lucide-react';

--- a/frontend/src/ui/composer/ComposerSurface.tsx
+++ b/frontend/src/ui/composer/ComposerSurface.tsx
@@ -8,7 +8,7 @@
  * This component is retained for ComposerPage and legacy drawer contexts.
  *
  * Core principles:
- * - Schema-first: Action types come from definitions with kind='action_recipe'
+ * - Schema-first: Action types come from definitions with kind='action_arrangement'
  * - References are first-class inputs with named slots
  * - Events are emitted, not stored directly (immutable facts)
  *
@@ -113,10 +113,10 @@ export function ComposerSurface({
 
     // ==================== DERIVED DATA ====================
 
-    // Filter definitions to only action_recipe kind
+    // Filter definitions to only action_arrangement kind
     const actionRecipes = useMemo(() => {
         if (!allDefinitions) return [];
-        return allDefinitions.filter((d) => d.kind === 'action_recipe');
+        return allDefinitions.filter((d) => d.kind === 'action_arrangement');
     }, [allDefinitions]);
 
     // Get selected recipe

--- a/frontend/src/ui/composer/UnifiedComposerBar.tsx
+++ b/frontend/src/ui/composer/UnifiedComposerBar.tsx
@@ -74,10 +74,10 @@ export function UnifiedComposerBar({
     // Store
     const { activeProjectId } = useUIStore();
 
-    // Filter to action recipes only
+    // Filter to action arrangements only
     const actionRecipes = useMemo(() => {
         if (!allDefinitions) return [];
-        return allDefinitions.filter((d) => d.kind === 'action_recipe');
+        return allDefinitions.filter((d) => d.kind === 'action_arrangement');
     }, [allDefinitions]);
 
     // Auto-select first recipe (Task by default)

--- a/frontend/src/ui/composites/ActionsTableFlat.tsx
+++ b/frontend/src/ui/composites/ActionsTableFlat.tsx
@@ -1,7 +1,7 @@
 /**
  * ActionsTableFlat - Reusable table composite for Action data
  *
- * This is a REUSABLE COMPOSITE for Action[] with RecordDefinition (action_recipe) schemas.
+ * This is a REUSABLE COMPOSITE for Action[] with RecordDefinition (action_arrangement) schemas.
  * It does NOT fetch data - data is passed in as props.
  *
  * Companion to DataTableFlat, but for actions (first-class entities).

--- a/frontend/src/ui/drawer/views/CreateDefinitionView.tsx
+++ b/frontend/src/ui/drawer/views/CreateDefinitionView.tsx
@@ -33,7 +33,7 @@ const PRESET_EMOJIS = ['📋', '📁', '👤', '🏢', '🎨', '📦', '🔧', '
 // Legacy props interface (deprecated - use DrawerProps)
 interface LegacyCreateDefinitionViewProps {
   copyFromId?: string;
-  definitionKind?: 'record' | 'action_recipe';
+  definitionKind?: 'record' | 'action_arrangement';
 }
 
 // New contract props
@@ -52,7 +52,7 @@ export function CreateDefinitionView(props: CreateDefinitionViewProps | LegacyCr
 
   // Get definitionKind from props (defaults to 'record')
   const definitionKind = (props as { definitionKind?: string }).definitionKind ?? 'record';
-  const isActionRecipe = definitionKind === 'action_recipe';
+  const isActionArrangement = definitionKind === 'action_arrangement';
 
   const { closeDrawer } = useUIStore();
   const createDefinition = useCreateDefinition();
@@ -143,7 +143,7 @@ export function CreateDefinitionView(props: CreateDefinitionViewProps | LegacyCr
             Create New
           </Text>
           <Text size="xl" weight="bold">
-            {isActionRecipe ? 'Action Definition' : 'Record Definition'}
+            {isActionArrangement ? 'Action Definition' : 'Record Definition'}
           </Text>
         </Stack>
       </Inline>
@@ -158,7 +158,7 @@ export function CreateDefinitionView(props: CreateDefinitionViewProps | LegacyCr
             onChange={(e) => setName(e.currentTarget.value)}
             required
             autoFocus
-            description={`This will be the display name for this ${isActionRecipe ? 'action' : 'record'} definition`}
+            description={`This will be the display name for this ${isActionArrangement ? 'action' : 'record'} definition`}
           />
 
           {/* Styling Section */}
@@ -257,7 +257,7 @@ export function CreateDefinitionView(props: CreateDefinitionViewProps | LegacyCr
               </div>
               <Stack gap="none">
                 <Text size="sm" weight="medium">
-                  {name.trim() || (isActionRecipe ? 'Action Definition Name' : 'Record Definition Name')}
+                  {name.trim() || (isActionArrangement ? 'Action Definition Name' : 'Record Definition Name')}
                 </Text>
                 <Text size="xs" color="muted">0 records</Text>
               </Stack>

--- a/frontend/src/ui/inspector/InspectorFooterComposer.tsx
+++ b/frontend/src/ui/inspector/InspectorFooterComposer.tsx
@@ -40,10 +40,10 @@ export function InspectorFooterComposer() {
     const { data: selectedNode } = useNode(nodeId);
     const { data: selectedAction } = useAction(actionId);
 
-    // Filter to action recipes only
+    // Filter to action arrangements only
     const actionRecipes = useMemo(() => {
         if (!allDefinitions) return [];
-        return allDefinitions.filter((d) => d.kind === 'action_recipe');
+        return allDefinitions.filter((d) => d.kind === 'action_arrangement');
     }, [allDefinitions]);
 
     // Auto-select first recipe

--- a/frontend/src/ui/panels/ActionsPanel.tsx
+++ b/frontend/src/ui/panels/ActionsPanel.tsx
@@ -56,7 +56,7 @@ export function ActionsPanel() {
                     width={sidebarWidth}
                     selectedDefinitionId={selectedDefinitionId}
                     onSelectDefinition={handleSelectDefinition}
-                    definitionKind="action_recipe"
+                    definitionKind="action_arrangement"
                 />
                 <ResizeHandle direction="right" onResize={handleSidebarResize} />
 

--- a/frontend/src/ui/records/RecordTypeSidebar.tsx
+++ b/frontend/src/ui/records/RecordTypeSidebar.tsx
@@ -14,10 +14,10 @@ interface RecordTypeSidebarProps {
 /**
  * Left sidebar showing available record definition types.
  * Displays each type with emoji icon, name, and record count.
- * 
+ *
  * Filtering logic:
  * - Shows only definitions with kind='record' (data definitions)
- * - Excludes kind='action_recipe' (Task, Subtask, etc.) which belong in Composer
+ * - Excludes kind='action_arrangement' (Task, etc.) which belong in Composer
  * - Also excludes legacy hierarchy node types by name as fallback
  */
 export function RecordTypeSidebar({

--- a/frontend/src/ui/records/RegistrySidebar.tsx
+++ b/frontend/src/ui/records/RegistrySidebar.tsx
@@ -54,7 +54,7 @@ export function RegistrySidebar({
     // Legacy hierarchy types to exclude
     const legacyHierarchyTypes = ['project', 'process', 'stage', 'subprocess'];
 
-    // Filter record definitions (exclude action_recipes from old system)
+    // Filter record definitions (exclude action_arrangements from old system)
     const recordDefinitions = (definitions || []).filter((def) => {
         const defKind = (def as { definition_kind?: string }).definition_kind;
         if (defKind) return defKind === 'record';


### PR DESCRIPTION
## **User description**
## Summary
- Updates all frontend `action_recipe` references to `action_arrangement`
- Covers active code (filters, type unions, props) and JSDoc comments
- Migration code in uiStore.ts intentionally retains old value

Closes #135

(Recreated from closed PR #153 after stack merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Rename UI references from "action_recipe" to "action_arrangement" so action definitions display and filter correctly

### What Changed
- Composer, inspector footer, and composer surface now show and auto-select action definitions identified as "action_arrangement" so the composer lists the intended action types
- Create definition dialog and preview use "action" wording when creating an action_arrangement, and its input description and preview text reflect the action type
- Sidebars, panels, and registry views exclude action_arrangement entries from record lists and use the new term in headers and notes so actions appear in the correct registries/tabs

### Impact
`✅ Composer shows correct action definitions`
`✅ Create dialog labels match action type`
`✅ Record lists no longer include action definitions` 
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
