### PR TITLE
fix: address PR review feedback

### DIFF
--- a/backend/src/modules/polls/polls.routes.ts
+++ b/backend/src/modules/polls/polls.routes.ts
@@ -230,6 +230,11 @@ export async function pollPublicRoutes(app: FastifyInstance) {
       },
     },
     async (request, reply) => {
+      const poll = await pollsService.getPollByUniqueId(request.params.uniqueId);
+      if (!poll || poll.status !== 'active') {
+        return reply.code(404).send({ error: 'NOT_FOUND', message: 'Poll not found' });
+      }
+
       await pollsService.logEngagement(
         EngagementContextType.POLL,
         request.params.uniqueId,

--- a/frontend/src/styles/dockview-theme.css
+++ b/frontend/src/styles/dockview-theme.css
@@ -113,7 +113,7 @@
 
 .dockview-theme-light .dv-default-tab-action:hover {
   color: var(--ws-fg);
-  background: var(--ws-tab-close-hover-bg);
+  background-color: var(--ws-tab-close-hover-bg) !important;
   border-radius: 4px;
 }
 


### PR DESCRIPTION
## **User description**
## Summary

Fixes issues identified in PR reviews:

- **dockview-theme.css**: Add `!important` to close button hover background to override the universal `background-color: transparent !important` rule
- **polls.routes.ts**: Verify poll exists and is active before logging engagement events (consistent with other public endpoints)

## Related PRs

- #204, #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Prevent engagement logging for missing/inactive polls and restore tab close hover background

### What Changed
- The public engagement endpoint now returns 404 if the referenced poll does not exist or is not active, so engagement events are not recorded for invalid polls
- The dockview tab close button hover shows the intended background color by applying the hover background rule with higher priority

### Impact
`✅ Fewer incorrect engagement records`
`✅ Clearer tab close hover visuals`
`✅ Prevents logging for inactive or non-existent polls`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
