### PR TITLE
feat(polls): TanStack Query hooks + workspace routing

### DIFF
--- a/frontend/src/api/hooks/index.ts
+++ b/frontend/src/api/hooks/index.ts
@@ -296,6 +296,16 @@ export {
   type InterpretationAvailability,
 } from './interpretation';
 
+// Polls (Availability polling)
+export {
+  usePolls,
+  usePoll,
+  useCreatePoll,
+  useClosePoll,
+  usePollResults,
+  pollsQueryKeys,
+} from './polls';
+
 // Mappings (Cross-entity relationships)
 export {
   useActionMappings,

--- a/frontend/src/api/hooks/polls.ts
+++ b/frontend/src/api/hooks/polls.ts
@@ -1,0 +1,121 @@
+/**
+ * Polls module React Query hooks
+ * Authenticated dashboard hooks for poll management
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '../client';
+import type { Poll, PollTimeConfig } from '@autoart/shared';
+
+interface PollWithResponses extends Poll {
+  responses: Array<{
+    id: string;
+    poll_id: string;
+    participant_name: string;
+    participant_email: string | null;
+    available_slots: string[];
+    created_at: string;
+    updated_at: string;
+  }>;
+}
+
+interface PollResultsData {
+  poll: Poll;
+  slotCounts: Record<string, number>;
+  bestSlots: string[];
+  totalResponses: number;
+}
+
+export const pollsQueryKeys = {
+  all: () => ['polls'] as const,
+  list: () => ['polls', 'list'] as const,
+  detail: (id: string) => ['polls', 'detail', id] as const,
+  results: (uniqueId: string) => ['polls', 'results', uniqueId] as const,
+  engagements: (id: string) => ['polls', 'engagements', id] as const,
+};
+
+/**
+ * Fetch all polls for the current user
+ */
+export function usePolls() {
+  return useQuery({
+    queryKey: pollsQueryKeys.list(),
+    queryFn: async () => {
+      const data = await api.get<{ polls: Poll[] }>('/polls');
+      return data.polls;
+    },
+    staleTime: 30000,
+  });
+}
+
+/**
+ * Fetch a single poll by ID with responses (owner-only)
+ */
+export function usePoll(id: string | null) {
+  return useQuery({
+    queryKey: pollsQueryKeys.detail(id || ''),
+    queryFn: async () => {
+      const data = await api.get<{ poll: PollWithResponses }>(`/polls/${id}`);
+      return data.poll;
+    },
+    enabled: !!id,
+  });
+}
+
+/**
+ * Create a new poll
+ */
+export function useCreatePoll() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (input: {
+      title: string;
+      description?: string;
+      time_config: PollTimeConfig;
+      project_id?: string;
+    }) => {
+      const data = await api.post<{ poll: Poll }>('/polls', input);
+      return data.poll;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: pollsQueryKeys.all() });
+    },
+  });
+}
+
+/**
+ * Close a poll (owner-only)
+ */
+export function useClosePoll() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const data = await api.post<{ poll: Poll }>(`/polls/${id}/close`);
+      return data.poll;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: pollsQueryKeys.all() });
+    },
+  });
+}
+
+/**
+ * Fetch aggregated results for a poll by uniqueId (public endpoint)
+ */
+export function usePollResults(uniqueId: string | null) {
+  return useQuery({
+    queryKey: pollsQueryKeys.results(uniqueId || ''),
+    queryFn: async () => {
+      const res = await fetch(
+        `${import.meta.env.VITE_API_URL || ''}/public/poll/${uniqueId}/results`
+      );
+      if (!res.ok) throw new Error('Failed to load results');
+      const data = await res.json();
+      return data.results as PollResultsData;
+    },
+    enabled: !!uniqueId,
+  });
+}

--- a/frontend/src/stores/uiStore.ts
+++ b/frontend/src/stores/uiStore.ts
@@ -22,7 +22,8 @@ export type CenterContentType =
   | 'intake'        // Data intake workflow
   | 'export'        // Export workflow
   | 'mail'          // Communication
-  | 'calendar';     // Calendar view
+  | 'calendar'      // Calendar view
+  | 'polls';        // Availability polls
 
 import { Selection, UIPanels, InspectorMode, OverlayConfig, InspectorTabId, normalizeInspectorTabId } from '../types/ui';
 import { deriveUIPanels } from '../utils/uiComposition';

--- a/frontend/src/ui/workspace/CenterContentRouter.tsx
+++ b/frontend/src/ui/workspace/CenterContentRouter.tsx
@@ -16,6 +16,7 @@ import {
     ExportContent,
     MailContent,
     CalendarContent,
+    PollsContent,
 } from './content';
 
 export function CenterContentRouter() {
@@ -34,6 +35,8 @@ export function CenterContentRouter() {
             return <MailContent />;
         case 'calendar':
             return <CalendarContent />;
+        case 'polls':
+            return <PollsContent />;
         default:
             // Fallback to projects (default behavior)
             return <ProjectContentAdapter />;

--- a/frontend/src/ui/workspace/content/PollsContent.tsx
+++ b/frontend/src/ui/workspace/content/PollsContent.tsx
@@ -1,0 +1,15 @@
+/**
+ * PollsContent
+ *
+ * Thin wrapper for embedding Polls view as center content.
+ */
+
+import { Text } from '@autoart/ui';
+
+export function PollsContent() {
+    return (
+        <div className="h-full flex items-center justify-center">
+            <Text color="dimmed">Polls workspace</Text>
+        </div>
+    );
+}

--- a/frontend/src/ui/workspace/content/index.ts
+++ b/frontend/src/ui/workspace/content/index.ts
@@ -10,3 +10,4 @@ export { IntakeContent } from './IntakeContent';
 export { ExportContent } from './ExportContent';
 export { MailContent } from './MailContent';
 export { CalendarContent } from './CalendarContent';
+export { PollsContent } from './PollsContent';


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #209**
  * **PR #210** 👈
    * **PR #211**
      * **PR #212**
        * **PR #213**
          * **PR #214**
            * **PR #215**
              * **PR #219**
                * **PR #220**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Add Polls workspace and TanStack Query hooks for poll management and public results

### What Changed
- A "Polls" center workspace option is available in the app and shows a centered "Polls workspace" placeholder view
- New front-end hooks to manage polls: list polls for the authenticated user, load a single poll with its responses (owner), create polls, and close polls; poll queries are invalidated/ refreshed after create/close
- New hook to load public aggregated poll results by a poll's public unique link; exported query keys allow consistent caching and refetching across the UI

### Impact
`✅ Can open a Polls workspace in the app`
`✅ Create and close polls from the authenticated dashboard`
`✅ View public aggregated poll results by unique link`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
