### PR TITLE
fix: wire ActionsPanel to open ComposerPanel instead of console.log

### DIFF
--- a/frontend/src/ui/panels/ActionsPanel.tsx
+++ b/frontend/src/ui/panels/ActionsPanel.tsx
@@ -7,16 +7,12 @@
 
 import { Zap } from 'lucide-react';
 import { useCallback, useState } from 'react';
-// import { useNavigate } from 'react-router-dom'; // No navigation
-
 import { ResizeHandle } from '@autoart/ui';
+import { useWorkspaceStore } from '../../stores/workspaceStore';
 import { RegistryPageHeader, DefinitionListSidebar, type RegistryTab } from '../registry';
 import { ActionInstancesView } from '../tables/ActionInstancesView';
 
 export function ActionsPanel() {
-    // const navigate = useNavigate();
-    // const { openOverlay } = useUIStore(); // We might use drawer or just open Composer panel
-
     // Note: ActionsPage handled inspector resizing globally via uiStore.
     // In Dockview, inspector resizing is handled by Dockview itself.
     // So we only handle local sidebar resizing.
@@ -37,15 +33,7 @@ export function ActionsPanel() {
     };
 
     const handleCreateDefinition = () => {
-        // Open Composer panel instead of navigating
-        // useWorkspaceStore.getState().openPanel('composer') ? Or open drawer?
-        // Current ActionsPage navigated to /composer.
-        // We probably want to open the Composer panel if we migrate it, or use the drawer.
-        // For now, let's assuming opening the Composer "drawer" (surface).
-        // Actually, previous ActionsPage navigated to /composer.
-        // I'll leave a TODO or open a drawer for now, or just notify 'Use Composer Panel'.
-        console.log('TODO: Open Composer Panel');
-        // If we make Composer a panel, we can open it.
+        useWorkspaceStore.getState().openPanel('composer-workbench');
     };
 
     return (


### PR DESCRIPTION
## **User description**
Replace dead console.log('TODO: Open Composer Panel') with
useWorkspaceStore.getState().openPanel('composer-workbench').
Clean up dead commented-out imports.


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #209**
  * **PR #210**
    * **PR #211**
      * **PR #212**
        * **PR #213**
          * **PR #214**
            * **PR #215**
              * **PR #219**
                * **PR #220** 👈

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
**Open Composer panel when creating an action from ActionsPanel**

### What Changed
- Clicking "Create definition" now opens the Composer panel ("composer-workbench") instead of logging a TODO to the console
- Removed dead console.log and unused commented imports so no leftover developer messages appear in the UI

### Impact
`✅ Opens Composer panel on action creation`
`✅ No leftover console TODO messages`
`✅ Consistent action-creation flow from ActionsPanel`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
