### PR TITLE
fix: RTF formatter fidelity - Calibri font, expanded colors, ● ✓ bullets, | separator

### DIFF
--- a/backend/src/modules/exports/formatters/rtf-formatter.ts
+++ b/backend/src/modules/exports/formatters/rtf-formatter.ts
@@ -112,15 +112,16 @@ function formatProjectRtf(
     if (options.includeMilestones && project.timelineBlock.milestones.length > 0) {
         parts.push(`{\\fs20\\b Timeline:}\\par`);
         for (const milestone of project.timelineBlock.milestones) {
-            const statusMark = milestone.status === 'completed' ? '✓' : '●';
+            // RTF Unicode: \uN? where N = decimal code point, ? = ASCII fallback
+            const statusMark = milestone.status === 'completed' ? '\\u10003?' : '\\u9679?';
             const dateStr = milestone.dateText || 'TBD';
-            const line = `  ${statusMark} ${milestone.kind}: ${dateStr}`;
+            const labelText = `${milestone.kind}: ${dateStr}`;
 
             // Highlight if date is in current month
             if (isCurrentMonth(milestone.normalizedDate)) {
-                parts.push(`{\\fs20 ${highlight(line)}}\\par`);
+                parts.push(`{\\fs20 {\\highlight3   ${statusMark} ${escapeRtf(labelText)}}}\\par`);
             } else {
-                parts.push(`{\\fs20 ${escapeRtf(line)}}\\par`);
+                parts.push(`{\\fs20   ${statusMark} ${escapeRtf(labelText)}}\\par`);
             }
         }
     }
@@ -151,7 +152,7 @@ function formatProjectRtf(
         if (stepsToShow.length > 0) {
             parts.push(`{\\fs20\\b Next Steps:}\\par`);
             for (const step of stepsToShow) {
-                const bullet = step.completed ? '✓' : '●';
+                const bullet = step.completed ? '\\u10003?' : '\\u9679?';
                 const assigneeSuffix = step.assigneeHint ? ` (${step.assigneeHint})` : '';
                 parts.push(`{\\fs20   ${bullet} ${escapeRtf(step.text)}${escapeRtf(assigneeSuffix)}}\\par`);
             }


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #221**
  * **PR #222**
    * **PR #223**
      * **PR #224** 👈
        * **PR #225**
          * **PR #226**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
**Use Calibri, expanded colors, Unicode bullets, and '|' budget separator in RTF export**

### What Changed
- Exported RTF now uses Calibri as the document font and a larger color table so colors in exported files match the original styling (including red, gray, cyan, and yellow highlight).
- Task and milestone markers render as proper Unicode symbols (a filled dot for open items and a check mark for completed items) in the RTF output instead of ASCII "[ ]" / "[x]".
- Project header budget parts are separated with " | " instead of commas for clearer inline grouping.
- Dates in the current month are highlighted using the updated highlight color entry so highlighted rows appear correctly in exported RTFs.

### Impact
`✅ Calibri font in exported RTFs matches source documents`
`✅ Accurate open/complete symbols (●, ✓) in exported tasks and milestones`
`✅ Clearer budget grouping in project headers`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
