### PR TITLE
fix: align section headers and bullet chars across formatters, populate bfaProjectStatusText

### DIFF
--- a/backend/src/modules/exports/connectors/google-docs-connector.ts
+++ b/backend/src/modules/exports/connectors/google-docs-connector.ts
@@ -287,17 +287,17 @@ export class GoogleDocsConnector {
         const privateCorpProjects = projects.filter(p => p.category === 'private_corporate');
 
         if (publicProjects.length > 0) {
-            sections.push('PUBLIC ART PROJECTS\n');
+            sections.push('PUBLIC ART\n');
             sections.push(...publicProjects.map(p => this.formatSingleProject(p, options)));
         }
 
         if (corporateProjects.length > 0) {
-            sections.push('\nCORPORATE PROJECTS\n');
+            sections.push('\nCORPORATE\n');
             sections.push(...corporateProjects.map(p => this.formatSingleProject(p, options)));
         }
 
         if (privateCorpProjects.length > 0) {
-            sections.push('\nPRIVATE CORPORATE PROJECTS\n');
+            sections.push('\nPRIVATE / CORPORATE\n');
             sections.push(...privateCorpProjects.map(p => this.formatSingleProject(p, options)));
         }
 
@@ -448,8 +448,8 @@ export class GoogleDocsConnector {
             });
         }
 
-        // Find and format section headers (PUBLIC ART PROJECTS, etc.)
-        const sectionHeaders = ['PUBLIC ART PROJECTS', 'CORPORATE PROJECTS', 'PRIVATE CORPORATE PROJECTS'];
+        // Find and format section headers (PUBLIC ART, etc.)
+        const sectionHeaders = ['PUBLIC ART', 'CORPORATE', 'PRIVATE / CORPORATE'];
 
         for (const header of sectionHeaders) {
             const index = text.indexOf(header);

--- a/backend/src/modules/exports/formatters/markdown-formatter.ts
+++ b/backend/src/modules/exports/formatters/markdown-formatter.ts
@@ -86,7 +86,7 @@ function formatProjectMarkdown(
     if (options.includeMilestones && project.timelineBlock.milestones.length > 0) {
         lines.push('**Timeline:**');
         for (const milestone of project.timelineBlock.milestones) {
-            const statusMark = milestone.status === 'completed' ? '[x]' : '[ ]';
+            const statusMark = milestone.status === 'completed' ? '✓' : '●';
             const dateStr = milestone.dateText || 'TBD';
             const highlight = isCurrentMonth(milestone.normalizedDate) ? ' ⚡' : '';
             lines.push(`- ${statusMark} **${milestone.kind}:** ${dateStr}${highlight}`);
@@ -122,7 +122,7 @@ function formatProjectMarkdown(
         if (stepsToShow.length > 0) {
             lines.push('**Next Steps:**');
             for (const step of stepsToShow) {
-                const bullet = step.completed ? '[x]' : '[ ]';
+                const bullet = step.completed ? '✓' : '●';
                 const assigneeSuffix = step.assigneeHint ? ` *(${step.assigneeHint})*` : '';
                 lines.push(`- ${bullet} ${step.text}${assigneeSuffix}`);
             }

--- a/backend/src/modules/exports/formatters/plaintext-formatter.ts
+++ b/backend/src/modules/exports/formatters/plaintext-formatter.ts
@@ -87,7 +87,7 @@ function formatProjectPlainText(
     if (options.includeMilestones && project.timelineBlock.milestones.length > 0) {
         lines.push('  Timeline:');
         for (const milestone of project.timelineBlock.milestones) {
-            const statusMark = milestone.status === 'completed' ? '[x]' : '[ ]';
+            const statusMark = milestone.status === 'completed' ? '✓' : '●';
             const dateStr = milestone.dateText || 'TBD';
             const highlight = isCurrentMonth(milestone.normalizedDate) ? ' <--' : '';
             lines.push(`    ${statusMark} ${milestone.kind}: ${dateStr}${highlight}`);
@@ -123,7 +123,7 @@ function formatProjectPlainText(
         if (stepsToShow.length > 0) {
             lines.push('  Next Steps:');
             for (const step of stepsToShow) {
-                const bullet = step.completed ? '[x]' : '[ ]';
+                const bullet = step.completed ? '✓' : '●';
                 const assigneeSuffix = step.assigneeHint ? ` (${step.assigneeHint})` : '';
                 lines.push(`    ${bullet} ${step.text}${assigneeSuffix}`);
             }

--- a/backend/src/modules/exports/projectors/bfa-project.projector.ts
+++ b/backend/src/modules/exports/projectors/bfa-project.projector.ts
@@ -100,6 +100,7 @@ async function projectSingleProject(
         statusBlock: {
             stage: currentStage,
             projectStatusText: extractProjectStatus(projectMetadata),
+            bfaProjectStatusText: extractBfaProjectStatus(projectMetadata),
         },
         nextStepsBullets: formatNextSteps(tasks),
         rawBlockText: '', // Will be generated from formatted content
@@ -458,6 +459,10 @@ function deriveCurrentStage(
 
 function extractProjectStatus(metadata: Record<string, unknown> | null): string | undefined {
     return (metadata?.status as string) || (metadata?.project_status as string);
+}
+
+function extractBfaProjectStatus(metadata: Record<string, unknown> | null): string | undefined {
+    return (metadata?.bfa_status as string) || (metadata?.bfa_project_status as string);
 }
 
 function formatNextSteps(


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #221**
  * **PR #222**
    * **PR #223**
      * **PR #224**
        * **PR #225** 👈
          * **PR #226**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
**Align export section headings and normalize checklist symbols; include BFA project status in exports**

### What Changed
- Export section headings now read "PUBLIC ART", "CORPORATE", and "PRIVATE / CORPORATE" in Google Docs, Markdown, and plain-text exports instead of the longer previous names
- Milestones and Next Steps show "✓" for completed and "●" for open in Markdown and plain-text exports (replacing "[x]" and "[ ]")
- BFA-specific project status is now included in exported project status text when present in project metadata

### Impact
`✅ Clearer exported section names`
`✅ Consistent checklist symbols across Markdown and plain-text exports`
`✅ BFA project status visible in export outputs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
