### PR TITLE
docs: update architecture docs to reflect current codebase (Jan 2026)

### DIFF
--- a/docs/ARCHITECTURE-00-INDEX.md
+++ b/docs/ARCHITECTURE-00-INDEX.md
@@ -1,8 +1,7 @@
 # AutoArt Architecture Documentation
 
-**Branch:** `experiment/foundational-model-refactor`  
-**Status:** Living documentation series  
-**Last Updated:** 2026-01-17
+**Status:** Living documentation series
+**Last Updated:** 2026-01-29
 
 ## Navigation
 
@@ -24,11 +23,20 @@ This documentation series describes AutoArt's architecture across multiple dimen
 - **[Architecture Inventory & Deprecation Plan](./architecture-inventory.md)**  
   Living inventory of active vs deprecated modules, migration status, and cleanup proposals.
 
-- **[Composer Documentation](./Composer-Docs.md)**  
+- **[Composer Documentation](./composer/composer-guide.md)**
   Deep dive into the Composer module (action creation, quick endpoints, event emission).
 
-- **[Execution Log Implementation](./plan-project-log-implementation.md)**  
+- **[Execution Log Implementation](./plan-project-log-implementation.md)**
   Technical plan for context-scoped event log views.
+
+- **Exports Architecture** (`backend/src/modules/exports/`)
+  Export session orchestration with sub-architecture: projectors, targets, formatters, connectors.
+
+- **Interpreter Mappings** (`backend/src/modules/interpreter/mappings/`)
+  11 domain-specific rule files for data interpretation (artwork, budget, communication, etc.).
+
+- **Workspace Themes** (`frontend/src/workspace/themes/`)
+  Theme presets (parchment, default, minimal, compact, floating) and CSS variable contract.
 
 ## Quick Reference
 
@@ -96,7 +104,6 @@ When adding new architectural decisions:
 
 ## Related Issues
 
-- [#63 Dockview workspace layout](https://github.com/ok-very/autoart/issues/63)
-- [#67 OverlayRegistry refactor](https://github.com/ok-very/autoart/issues/67)
-- [#65 SelectionInspector surface](https://github.com/ok-very/autoart/issues/65)
+- [#62 Multi-window popouts + context sync](https://github.com/ok-very/autoart/issues/62)
+- [#64 Electron SPA shell](https://github.com/ok-very/autoart/issues/64)
 - [#66 Mail surface](https://github.com/ok-very/autoart/issues/66)

--- a/docs/ARCHITECTURE-01-BACKEND.md
+++ b/docs/ARCHITECTURE-01-BACKEND.md
@@ -1,7 +1,7 @@
 # Backend Architecture
 
 **Part of:** [Architecture Documentation Series](./ARCHITECTURE-00-INDEX.md)  
-**Last Updated:** 2026-01-17
+**Last Updated:** 2026-01-29
 
 ## Module Structure
 
@@ -20,18 +20,30 @@ module/
 
 ```
 backend/src/modules/
-├── actions/         # Action & event management (Intent declarations)
+├── actions/         # Action management (Intent declarations)
 ├── auth/            # Authentication & sessions
 ├── composer/        # Action composition (creates actions + events)
+├── definitions/     # Record definition CRUD
 ├── events/          # Event querying & workflow surfaces (Historical facts)
-├── exports/         # BFA export functionality
+├── exports/         # Export session orchestration
+│   ├── projectors/  #   Data projection (e.g., bfa-project.projector)
+│   ├── targets/     #   Output targets (Google Docs, PDF, RTF)
+│   ├── formatters/  #   Content formatting (markdown, plaintext, RTF)
+│   └── connectors/  #   External service connectors (Google Sheets/Docs/Slides)
+├── gc/              # Garbage collection
 ├── hierarchy/       # Project hierarchy (nodes)
-├── imports/         # CSV/Monday import & classification
+├── imports/         # CSV/Monday import, classification, webhooks
+├── intake/          # Public intake forms
 ├── interpreter/     # Data interpretation & mapping rules
+│   └── mappings/    #   11 domain-specific rule files (artwork, budget, communication,
+│                    #   decision, document, intent-mapping, invoice, meeting, permit,
+│                    #   process, stage)
 ├── links/           # Record-to-record links
+├── polls/           # Scheduling polls
 ├── projections/     # Projection presets & views (Derived state)
-├── records/         # Record definitions & instances (Context containers)
+├── records/         # Records + fact-kinds (Context containers)
 ├── references/      # Action/task references
+├── runner/          # AutoHelper runner connector
 └── search/          # Full-text search
 ```
 
@@ -96,18 +108,27 @@ Configured in `tsconfig.json`:
 ```mermaid
 graph TD
     A[actions] --> S[@autoart/shared]
+    AU[auth] --> S
     C[composer] --> S
     C --> A
+    D[definitions] --> S
     E[events] --> S
     E --> A
+    EX[exports] --> S
+    GC[gc] --> S
+    H[hierarchy] --> S
     I[imports] --> S
     I --> INT[interpreter]
-    EX[exports] --> S
-    H[hierarchy] --> S
-    R[records] --> S
-    REF[references] --> S
+    IN[intake] --> S
+    IN --> D
+    INT --> S
     L[links] --> S
+    PO[polls] --> S
     P[projections] --> S
+    R[records] --> S
+    R --> D
+    REF[references] --> S
+    RU[runner] --> S
     SE[search] --> S
 ```
 
@@ -232,5 +253,5 @@ if (!isValid) {
 ## Next Steps
 
 - Read [Foundational Model](./ARCHITECTURE-02-FOUNDATIONAL-MODEL.md) to understand the four first-class objects
-- Review [Composer Documentation](./Composer-Docs.md) for action creation patterns
+- Review [Composer Documentation](./composer/composer-guide.md) for action creation patterns
 - See [Architecture Inventory](./architecture-inventory.md) for deprecation status

--- a/docs/architecture-inventory.md
+++ b/docs/architecture-inventory.md
@@ -1,30 +1,44 @@
 # Architecture Inventory & Deprecation Plan
 
 **Status:** Living Document
-**Last Updated:** 2026-01-03
+**Last Updated:** 2026-01-29
 
 ## 1. System Overview
 
-The system is transitioning from a direct CRUD model to an **Action-Event** driven architecture, centered around the **Composer** module.
+The system uses an **Action-Event** driven architecture, centered around the **Composer** module. All mutations flow through Composer → Actions → Events.
 
-### Core Modules (New System)
+### Core Modules
 
 | Module | Location | Purpose | Key Endpoints |
 |---|---|---|---|
 | **Composer** | `backend/src/modules/composer` | Single entry point for creating work items via the Action+Event model. See [Composer Guide](./composer/composer-guide.md). | `POST /composer` |
 | **Actions** | `backend/src/modules/actions` | Manages "Intents" or actions that trigger workflows. Actions are immutable. | `POST /actions`<br>`GET /actions/:id` |
 | **Events** | `backend/src/modules/events` | Event stream handling side-effects of Actions. | - |
-| **Drawers** | `frontend/src/components/drawer` | Unified UI for contextual views, replacing Modals. | N/A |
+| **Overlays** | `frontend/src/ui/overlay/` + `ui/registry/OverlayRegistry.tsx` | Global transient workflow host (create/confirm/picker flows). 20 registered overlay types. | N/A |
+| **Workspace** | `frontend/src/workspace/` | Panel registry, workspace presets (7), theme system (5 presets), content routing. | N/A |
 
-### Active Modules (Standard)
+### Active Backend Modules
 
 | Module | Location | Purpose |
 |---|---|---|
-| **Auth** | `backend/src/modules/auth` | Authentication & Sessions. |
-| **Hierarchy** | `backend/src/modules/hierarchy` | Tree/Hierarchy visualization and management. |
-| **Ingestion** | `backend/src/modules/ingestion` | Data import parsers (e.g., Airtable). |
-| **Search** | `backend/src/modules/search` | Global search functionality. |
+| **Actions** | `backend/src/modules/actions` | Intent declarations (immutable). |
+| **Auth** | `backend/src/modules/auth` | Authentication & sessions. |
+| **Composer** | `backend/src/modules/composer` | Action composition (creates actions + events). |
+| **Definitions** | `backend/src/modules/definitions` | Record definition CRUD. |
+| **Events** | `backend/src/modules/events` | Event querying & workflow surfaces. |
+| **Exports** | `backend/src/modules/exports` | Export session orchestration (projectors/, targets/, formatters/, connectors/). |
+| **GC** | `backend/src/modules/gc` | Garbage collection. |
+| **Hierarchy** | `backend/src/modules/hierarchy` | Tree/hierarchy visualization and management. |
+| **Imports** | `backend/src/modules/imports` | CSV/Monday import, classification, webhooks. |
+| **Intake** | `backend/src/modules/intake` | Public intake forms. |
+| **Interpreter** | `backend/src/modules/interpreter` | Data interpretation + 11 domain-specific mapping rule files. |
 | **Links** | `backend/src/modules/links` | Record-to-record relationships. |
+| **Polls** | `backend/src/modules/polls` | Scheduling polls. |
+| **Projections** | `backend/src/modules/projections` | Workflow surface projectors (derived state). |
+| **Records** | `backend/src/modules/records` | Records + fact-kinds (context containers). |
+| **References** | `backend/src/modules/references` | Action/task references. |
+| **Runner** | `backend/src/modules/runner` | AutoHelper runner connector. |
+| **Search** | `backend/src/modules/search` | Full-text search. |
 
 ## 2. Legacy Inventory
 
@@ -32,10 +46,12 @@ Components identified as deprecated or superseded by the new system.
 
 | Component | Location | Status | Replacement |
 |---|---|---|---|
-| **Modals** | `frontend/src/components/modals` | **Dead Code** | `frontend/src/components/drawer` |
+| **Modals** | `frontend/src/components/modals` | **Removed** | `frontend/src/ui/overlay/` + `OverlayRegistry` |
+| **Drawers / DrawerRegistry** | `frontend/src/components/drawer` | **Removed** | `frontend/src/ui/overlay/` + `OverlayRegistry` |
 | **Legacy Task Tables** | `TaskDataTable.tsx` | **Removed** | `DataTableHierarchy` / `DataTableFlat` |
-| **Ingestion Drawer** | `IngestionDrawer.tsx` | **Removed** | Ingestion View Mode |
+| **Ingestion Drawer** | `IngestionDrawer.tsx` | **Removed** | Imports module (`backend/src/modules/imports`) |
 | **Project Templates** | `cloneProjectTemplates` | **Removed** | `cloneProjectDefinitions` |
+| **Ingestion module** | `backend/src/modules/ingestion` | **Removed** | Renamed to `imports/` |
 
 ---
 
@@ -43,40 +59,28 @@ Components identified as deprecated or superseded by the new system.
 
 ### Proposal 1: Remove `frontend/src/components/modals` Directory
 
-**Reasoning:**
-The `modals` directory contains `AddFieldModal.tsx`, `ConfirmDeleteModal.tsx`, `CreateNodeModal.tsx`, and `Modal.tsx`.
-- **Investigation:** A grep search for `from .*modals` in `frontend/src` returned **0 results**.
-- **Conclusion:** These files are completely disconnected from the application.
-- **Risk:** None. The code is unreachable.
-
-**Action:** Delete the directory.
+**Status: DONE** — directory deleted. The overlay system (`OverlayRegistry`) fully replaces modal-based workflows.
 
 ### Proposal 2: Enforce Composer for All Creations
 
-**Reasoning:**
+**Status: Open**
+
 The `composer` module (`POST /composer`) is designed as the single entry point for creating task-like entities to ensure proper Action/Event generation.
-- **Observation:** Direct creation endpoints might still exist in legacy modules (e.g. `records` or `tasks` old endpoints), though `Composer` is now the preferred path.
 - **Recommendation:** Audit `records.routes.ts` or `hierarchy.routes.ts` for direct CREATE operations and mark them as `@deprecated`.
 
 ### Proposal 3: Clean up `clone_excluded` Logic
 
-**Reasoning:**
+**Status: Open**
+
 Documentation mentions `project_id` on `record_definitions` as driving template library logic, and it's potentially legacy.
 - **Action:** Verify if `clone_excluded` fully covers the requirement and remove the old `project_id` based logic if unused.
+
 ## Flags
 
-- **Dead Code:** The `frontend/src/components/modals` directory contains files that are never imported or used in the application.
-- **Missing Component:** `IngestionDrawer.tsx` is referenced in the legacy inventory but does not exist in the codebase.
-- **Documentation Gap:** The README does not mention the new `Drawer` system that replaces modals, leading to potential confusion for new developers.
-- **Header Comments:** Several backend module entry files (e.g., `backend/src/modules/composer/index.ts`, `backend/src/modules/actions/index.ts`) lack top‑level comment headers describing their purpose.
-- **Legacy References:** Documentation still references `Legacy Task Tables` and `Project Templates` which have been removed; these references should be cleaned up.
 - **Composer Usage:** Some API routes in `backend/src/modules/records` still expose direct creation endpoints that bypass the Composer; these should be flagged for deprecation.
 - **Missing Header Comments – Backend Modules:** `backend/src/modules/composer/composer.routes.ts`, `composer.service.ts`, `actions.routes.ts`, `events.routes.ts` lack file‑level comment headers.
-- **Missing Header Comments – Frontend Components:** `frontend/src/components/drawer/DrawerRegistry.tsx`, `drawer/views/ActionInspectorDrawer.tsx`, `inspector/ActionInspector.tsx` lack introductory comments.
-- **Inconsistent Naming – Legacy Files:** `TaskDataTable.tsx` is listed but the file has been removed.
 - **Out‑of‑Date API Documentation:** README lists `npm run dev` for Windows, but the correct command is `npm run dev:win`.
 - **Undocumented Environment Variables:** `.env.example` contains `SMTP_HOST` and `SMTP_PORT` not referenced in docs.
-- **Missing Tests for New Modules:** No test files for `backend/src/modules/composer` and `frontend/src/components/drawer`.
-- **Unreferenced UI Assets:** SVG icons in `frontend/src/components/drawer` are not imported.
+- **Missing Tests for New Modules:** No test files for `backend/src/modules/composer`.
 - **Stale Documentation Links:** Demo URLs in README point to outdated paths.
 - **Missing Export Statements:** Module index files (e.g., `backend/src/modules/records/index.ts`) do not re‑export sub‑modules.


### PR DESCRIPTION
## **User description**
- architecture-inventory.md: Remove Drawers row, add Overlays + Workspace
  to core modules, add all 18 backend modules, mark modals as Removed,
  mark Proposal 1 DONE, clean up stale flags
- ARCHITECTURE-01-BACKEND.md: Add 6 missing modules (definitions, gc,
  intake, polls, runner, definitions), expand exports/ and interpreter/
  sub-architecture, update dependency graph
- ARCHITECTURE-03-FRONTEND-WORKSPACE.md: Document 16 panel IDs by
  category, list all 20 overlay types, add workspace presets (7),
  theme system (5 presets), content routing sections, remove closed issues
- ARCHITECTURE-00-INDEX.md: Remove closed issues (#63, #65, #67), fix
  Composer doc path, add exports/interpreter/themes to supplementary docs

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>


___

## **CodeAnt-AI Description**
Update architecture docs to match current codebase (Jan 29, 2026)

### What Changed
- Updated index links and added brief summaries for Exports, Interpreter mappings, and Workspace Themes so documentation points to actual code locations.
- Backend architecture now lists six added modules (definitions, gc, intake, polls, runner, exports sub-structure) and shows an updated dependency graph reflecting those modules.
- Frontend workspace docs enumerate 16 panel IDs, 20 overlay types, 7 workspace presets, a 5‑preset theme system, and content-routing patterns so UI surface behavior is documented and discoverable.
- Architecture inventory marks modals/drawers removed, records module updates, notes Composer as the creation entry point (Proposal 1 marked DONE), and cleans up several stale flags and broken links.

### Impact
`✅ Clearer module inventory`
`✅ Shorter onboarding for frontend/backend workflows`
`✅ Fewer broken or outdated doc links`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>