### PR TITLE
feat: email draft creation via Graph API with Outlook COM fallback

### DIFF
--- a/apps/autohelper/autohelper/modules/context/autoart.py
+++ b/apps/autohelper/autohelper/modules/context/autoart.py
@@ -241,6 +241,37 @@ class AutoArtClient:
             logger.error(f"Credential fetch failed: {e}")
             return None
 
+    def get_microsoft_token(self, session_id: str) -> str | None:
+        """
+        Fetch Microsoft Graph token from AutoArt using session credentials.
+
+        Args:
+            session_id: Valid session ID from pairing
+
+        Returns:
+            Microsoft Graph access token on success, None on failure
+        """
+        try:
+            response = requests.get(
+                f"{self.api_url}/api/connections/autohelper/credentials",
+                headers={"X-AutoHelper-Session": session_id, "Content-Type": "application/json"},
+                timeout=10,
+            )
+
+            if response.status_code == 200:
+                result = response.json()
+                token = result.get("microsoft_graph_token")
+                if token:
+                    logger.debug("Retrieved Microsoft Graph token from AutoArt")
+                    return token
+
+            logger.warning(f"Failed to get Microsoft token: {response.status_code}")
+            return None
+
+        except requests.RequestException as e:
+            logger.error(f"Microsoft credential fetch failed: {e}")
+            return None
+
     def verify_session(self, session_id: str) -> bool:
         """
         Verify that a session ID is still valid.

--- a/apps/autohelper/autohelper/modules/mail/__init__.py
+++ b/apps/autohelper/autohelper/modules/mail/__init__.py
@@ -1,5 +1,7 @@
 from .router import router as mail_router
 from .schemas import (
+    CreateDraftRequest,
+    CreateDraftResponse,
     IngestionLogEntry,
     IngestionLogList,
     IngestRequest,
@@ -11,6 +13,8 @@ from .schemas import (
 from .service import MailService
 
 __all__ = [
+    "CreateDraftRequest",
+    "CreateDraftResponse",
     "MailService",
     "mail_router",
     "MailServiceStatus",

--- a/apps/autohelper/autohelper/modules/mail/draft.py
+++ b/apps/autohelper/autohelper/modules/mail/draft.py
@@ -1,0 +1,163 @@
+"""
+Email draft creation service.
+
+Dual-strategy approach:
+1. Microsoft Graph API (primary) — creates draft in user's mailbox via Entra token
+2. Outlook COM automation (fallback) — creates draft locally via win32com on Windows
+"""
+
+import logging
+import platform
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+GRAPH_API_BASE = "https://graph.microsoft.com/v1.0"
+
+
+class DraftCreationError(Exception):
+    """Raised when draft creation fails."""
+
+    def __init__(self, message: str, strategy: str):
+        super().__init__(message)
+        self.strategy = strategy
+
+
+def can_use_outlook() -> bool:
+    """Check if Outlook COM automation is available (Windows + pywin32)."""
+    if platform.system() != "Windows":
+        return False
+    try:
+        import win32com.client  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+async def create_draft_via_graph(
+    token: str,
+    to: str,
+    subject: str,
+    body: str,
+    cc: str | None = None,
+    body_type: str = "Text",
+) -> dict[str, Any]:
+    """
+    Create an email draft using the Microsoft Graph API.
+
+    Args:
+        token: Microsoft Graph access token with Mail.ReadWrite scope
+        to: Recipient email address
+        subject: Email subject
+        body: Email body content
+        cc: CC recipient email address (optional)
+        body_type: "Text" or "HTML"
+
+    Returns:
+        Dict with id, subject, and webLink of the created draft
+
+    Raises:
+        DraftCreationError: If the API call fails
+    """
+    message: dict[str, Any] = {
+        "subject": subject,
+        "body": {
+            "contentType": body_type,
+            "content": body,
+        },
+        "toRecipients": [
+            {"emailAddress": {"address": to}},
+        ],
+    }
+
+    if cc:
+        message["ccRecipients"] = [
+            {"emailAddress": {"address": addr.strip()}}
+            for addr in cc.split(",")
+            if addr.strip()
+        ]
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{GRAPH_API_BASE}/me/messages",
+            json=message,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            timeout=15,
+        )
+
+    if response.status_code not in (200, 201):
+        error_text = response.text
+        logger.error(f"Graph API draft creation failed: {response.status_code} {error_text}")
+        raise DraftCreationError(
+            f"Graph API returned {response.status_code}: {error_text}",
+            strategy="graph",
+        )
+
+    data = response.json()
+    return {
+        "id": data.get("id"),
+        "subject": data.get("subject"),
+        "web_link": data.get("webLink"),
+    }
+
+
+def create_draft_via_com(
+    to: str,
+    subject: str,
+    body: str,
+    cc: str | None = None,
+) -> dict[str, Any]:
+    """
+    Create an email draft using Outlook COM automation (Windows only).
+
+    Args:
+        to: Recipient email address
+        subject: Email subject
+        body: Email body content
+        cc: CC recipient email address (optional)
+
+    Returns:
+        Dict with subject of the created draft
+
+    Raises:
+        DraftCreationError: If COM automation fails or is unavailable
+    """
+    if not can_use_outlook():
+        raise DraftCreationError(
+            "Outlook COM not available (requires Windows with pywin32 and Outlook installed)",
+            strategy="outlook_com",
+        )
+
+    try:
+        import pythoncom
+        import win32com.client
+
+        pythoncom.CoInitialize()
+        try:
+            outlook = win32com.client.Dispatch("Outlook.Application")
+            mail_item = outlook.CreateItem(0)  # 0 = olMailItem
+            mail_item.To = to
+            mail_item.Subject = subject
+            mail_item.Body = body
+            if cc:
+                mail_item.CC = cc
+            mail_item.Save()
+
+            return {
+                "subject": subject,
+            }
+        finally:
+            pythoncom.CoUninitialize()
+
+    except Exception as e:
+        logger.error(f"Outlook COM draft creation failed: {e}")
+        raise DraftCreationError(
+            f"Outlook COM failed: {e}",
+            strategy="outlook_com",
+        ) from e

--- a/apps/autohelper/autohelper/modules/mail/schemas.py
+++ b/apps/autohelper/autohelper/modules/mail/schemas.py
@@ -85,3 +85,28 @@ class IngestResponse(BaseModel):
     success: bool
     count: int | None = None
     error: str | None = None
+
+
+# =============================================================================
+# DRAFTS
+# =============================================================================
+
+
+class CreateDraftRequest(BaseModel):
+    """Request to create an email draft in Outlook."""
+
+    to: str = Field(..., description="Recipient email address")
+    subject: str = Field(..., description="Email subject line")
+    body: str = Field(..., description="Email body content")
+    cc: str | None = Field(None, description="CC recipient(s), comma-separated")
+    body_type: str = Field("Text", description="Body content type: Text or HTML")
+
+
+class CreateDraftResponse(BaseModel):
+    """Response from draft creation."""
+
+    success: bool
+    method: str | None = Field(None, description="Strategy used: graph or outlook_com")
+    subject: str | None = None
+    message_id: str | None = None
+    error: str | None = None

--- a/apps/mail/src/components/DetailView.tsx
+++ b/apps/mail/src/components/DetailView.tsx
@@ -129,7 +129,7 @@ export function DetailView({ email }: DetailViewProps) {
         if (!email || !generatedDraft) return;
 
         try {
-            const response = await fetch(`${API_BASE}/mail/api/draft/send-to-outlook`, {
+            const response = await fetch(`${API_BASE}/mail/draft`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({

--- a/apps/mail/src/lib/api.ts
+++ b/apps/mail/src/lib/api.ts
@@ -2,7 +2,7 @@
  * API client utilities for mail app
  */
 
-export const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+export const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8100';
 
 export interface Email {
     id: string;

--- a/backend/src/modules/auth/microsoft-oauth.service.ts
+++ b/backend/src/modules/auth/microsoft-oauth.service.ts
@@ -26,9 +26,10 @@ const MICROSOFT_AUTH_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0
 const MICROSOFT_TOKEN_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/token';
 const MICROSOFT_USERINFO_URL = 'https://graph.microsoft.com/v1.0/me';
 
-// Scopes for OneDrive file access
+// Scopes for OneDrive file access + Mail draft creation
 const SCOPES = [
     'Files.ReadWrite.All',
+    'Mail.ReadWrite',
     'offline_access',
     'User.Read',
 ].join(' ');

--- a/backend/src/modules/imports/connections.service.ts
+++ b/backend/src/modules/imports/connections.service.ts
@@ -265,7 +265,7 @@ async function refreshMicrosoftToken(credential: ConnectionCredential): Promise<
             client_secret: clientSecret,
             refresh_token: credential.refresh_token!,
             grant_type: 'refresh_token',
-            scope: 'Files.ReadWrite.All offline_access User.Read',
+            scope: 'Files.ReadWrite.All Mail.ReadWrite offline_access User.Read',
         }),
     });
 
@@ -473,6 +473,21 @@ export async function getProxiedMondayToken(sessionId: string): Promise<string |
 
     try {
         return await getMondayToken(userId);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Get Microsoft Graph token for a trusted AutoHelper session.
+ * This proxies credentials without exposing them to the client.
+ */
+export async function getProxiedMicrosoftToken(sessionId: string): Promise<string | null> {
+    const userId = validateSession(sessionId);
+    if (!userId) return null;
+
+    try {
+        return await getMicrosoftToken(userId);
     } catch {
         return null;
     }


### PR DESCRIPTION
## **User description**


___

## **CodeAnt-AI Description**
Create Outlook email drafts from the app using Microsoft Graph with a Windows COM fallback

### What Changed
- Mail UI "Send to Outlook" now posts to a new backend endpoint that creates an Outlook draft
- Backend tries to create the draft via Microsoft Graph using a proxied AutoArt session token, and if that fails falls back to Outlook COM automation on Windows
- AutoArt/AutoHelper routes now return a proxied Microsoft Graph token alongside the Monday token so the backend can call Graph on behalf of the user
- Draft creation responses indicate which strategy succeeded; if both strategies fail the API returns a 502 with both error reasons
- Development API base default port changed from 8000 to 8100

### Impact
`✅ Can create Outlook drafts from the mail UI`
`✅ Fewer draft creation failures thanks to Graph→COM fallback`
`✅ Access to Microsoft Graph token via AutoHelper for backend proxy calls`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
