### PR TITLE
fix: address review findings (httpx error handling, config apply, tray polling, join race)

### DIFF
--- a/apps/autohelper/autohelper/gui/icon.py
+++ b/apps/autohelper/autohelper/gui/icon.py
@@ -133,7 +133,10 @@ class AutoHelperIcon:
         from autohelper.config import get_settings
 
         settings = get_settings()
-        base = f"http://{settings.host}:{settings.port}"
+        host = settings.host
+        if host in ("0.0.0.0", "::"):
+            host = "127.0.0.1"
+        base = f"http://{host}:{settings.port}"
 
         # Runner
         with urllib.request.urlopen(f"{base}/runner/status", timeout=2) as resp:

--- a/apps/autohelper/autohelper/gui/popup.py
+++ b/apps/autohelper/autohelper/gui/popup.py
@@ -17,7 +17,7 @@ def _settings_url() -> str:
     from autohelper.config import get_settings
 
     api_url = get_settings().autoart_api_url  # e.g. "http://localhost:3001"
-    return f"{api_url.rstrip('/')}/settings"
+    return f"{api_url.rstrip('/')}/settings#autohelper"
 
 
 def open_settings_in_browser() -> None:

--- a/apps/autohelper/autohelper/main.py
+++ b/apps/autohelper/autohelper/main.py
@@ -43,7 +43,7 @@ def _run_with_tray(server: uvicorn.Server) -> None:
         print(f"Tray icon failed: {e}")
         print("Falling back to console mode.")
         server.should_exit = True
-        server_thread.join(timeout=2)
+        server_thread.join()
         # Rebuild and run on main thread
         settings = get_settings()
         fallback_config = uvicorn.Config(

--- a/apps/autohelper/autohelper/modules/config/router.py
+++ b/apps/autohelper/autohelper/modules/config/router.py
@@ -41,10 +41,16 @@ async def put_config(body: dict[str, Any]) -> dict[str, Any]:
 
         svc = MailService()
         svc.stop()
-        # Re-read settings so the singleton picks up new config
+        # Re-read settings and apply persisted config values
         from autohelper.config import get_settings
 
-        svc.settings = get_settings()
+        settings = get_settings()
+        if "mail_enabled" in current:
+            settings.mail_enabled = bool(current["mail_enabled"])
+        if "mail_poll_interval" in current:
+            settings.mail_poll_interval = int(current["mail_poll_interval"])
+
+        svc.settings = settings
         svc.start()
     except Exception as exc:
         logger.warning("Failed to reinit mail service after config change: %s", exc)

--- a/apps/autohelper/autohelper/modules/mail/draft.py
+++ b/apps/autohelper/autohelper/modules/mail/draft.py
@@ -1,0 +1,170 @@
+"""
+Email draft creation service.
+
+Dual-strategy approach:
+1. Microsoft Graph API (primary) — creates draft in user's mailbox via Entra token
+2. Outlook COM automation (fallback) — creates draft locally via win32com on Windows
+"""
+
+import logging
+import platform
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+GRAPH_API_BASE = "https://graph.microsoft.com/v1.0"
+
+
+class DraftCreationError(Exception):
+    """Raised when draft creation fails."""
+
+    def __init__(self, message: str, strategy: str):
+        super().__init__(message)
+        self.strategy = strategy
+
+
+def can_use_outlook() -> bool:
+    """Check if Outlook COM automation is available (Windows + pywin32)."""
+    if platform.system() != "Windows":
+        return False
+    try:
+        import win32com.client  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+async def create_draft_via_graph(
+    token: str,
+    to: str,
+    subject: str,
+    body: str,
+    cc: str | None = None,
+    body_type: str = "Text",
+) -> dict[str, Any]:
+    """
+    Create an email draft using the Microsoft Graph API.
+
+    Args:
+        token: Microsoft Graph access token with Mail.ReadWrite scope
+        to: Recipient email address
+        subject: Email subject
+        body: Email body content
+        cc: CC recipient email address (optional)
+        body_type: "Text" or "HTML"
+
+    Returns:
+        Dict with id, subject, and webLink of the created draft
+
+    Raises:
+        DraftCreationError: If the API call fails
+    """
+    message: dict[str, Any] = {
+        "subject": subject,
+        "body": {
+            "contentType": body_type,
+            "content": body,
+        },
+        "toRecipients": [
+            {"emailAddress": {"address": to}},
+        ],
+    }
+
+    if cc:
+        message["ccRecipients"] = [
+            {"emailAddress": {"address": addr.strip()}}
+            for addr in cc.split(",")
+            if addr.strip()
+        ]
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{GRAPH_API_BASE}/me/messages",
+                json=message,
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Content-Type": "application/json",
+                },
+                timeout=15,
+            )
+    except httpx.RequestError as e:
+        logger.error(f"Graph API draft creation request failed: {e}")
+        raise DraftCreationError(
+            f"Graph API request failed: {e}",
+            strategy="graph",
+        ) from e
+
+    if response.status_code not in (200, 201):
+        error_text = response.text
+        logger.error(f"Graph API draft creation failed: {response.status_code} {error_text}")
+        raise DraftCreationError(
+            f"Graph API returned {response.status_code}: {error_text}",
+            strategy="graph",
+        )
+
+    data = response.json()
+    return {
+        "id": data.get("id"),
+        "subject": data.get("subject"),
+        "web_link": data.get("webLink"),
+    }
+
+
+def create_draft_via_com(
+    to: str,
+    subject: str,
+    body: str,
+    cc: str | None = None,
+) -> dict[str, Any]:
+    """
+    Create an email draft using Outlook COM automation (Windows only).
+
+    Args:
+        to: Recipient email address
+        subject: Email subject
+        body: Email body content
+        cc: CC recipient email address (optional)
+
+    Returns:
+        Dict with subject of the created draft
+
+    Raises:
+        DraftCreationError: If COM automation fails or is unavailable
+    """
+    if not can_use_outlook():
+        raise DraftCreationError(
+            "Outlook COM not available (requires Windows with pywin32 and Outlook installed)",
+            strategy="outlook_com",
+        )
+
+    try:
+        import pythoncom
+        import win32com.client
+
+        pythoncom.CoInitialize()
+        try:
+            outlook = win32com.client.Dispatch("Outlook.Application")
+            mail_item = outlook.CreateItem(0)  # 0 = olMailItem
+            mail_item.To = to
+            mail_item.Subject = subject
+            mail_item.Body = body
+            if cc:
+                mail_item.CC = cc
+            mail_item.Save()
+
+            return {
+                "subject": subject,
+            }
+        finally:
+            pythoncom.CoUninitialize()
+
+    except Exception as e:
+        logger.error(f"Outlook COM draft creation failed: {e}")
+        raise DraftCreationError(
+            f"Outlook COM failed: {e}",
+            strategy="outlook_com",
+        ) from e


### PR DESCRIPTION
## **User description**
## Summary
- Wrap Graph API httpx call in `try/except httpx.RequestError` so network failures raise `DraftCreationError` and trigger COM fallback
- Apply persisted config values (`mail_enabled`, `mail_poll_interval`) onto Settings singleton in PUT /config handler
- Substitute `0.0.0.0`/`::` with `127.0.0.1` for tray status polling URL
- Remove `timeout=2` from fallback server thread join to prevent port-in-use race
- Add `#autohelper` fragment to settings URL in popup.py

## Test plan
- [x] Draft creation falls back to COM on network error
- [x] Config PUT applies mail settings at runtime
- [x] Tray polling works with `0.0.0.0` bind address

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Fix tray polling and config reload; add Graph + Outlook draft creation with safe fallback**

### What Changed
- Tray status checks now poll localhost even when the server is bound to 0.0.0.0 or ::, preventing failed job-status lookups
- Changing mail-related settings via the config UI applies immediately so mail polling and enabled state update at runtime
- Tray shutdown no longer can hang waiting on the server thread; fallback server reliably starts on the main thread after tray failure
- Added email draft creation: attempts Microsoft Graph API first and, on network/API failure, raises a clear error for callers; on Windows, an Outlook COM fallback is available to save drafts locally
- Settings link opened from the UI now includes a fragment that targets the settings page in the frontend

### Impact
`✅ Reliable tray status polling when backend binds to 0.0.0.0`
`✅ Settings changes to mail behavior take effect immediately without restart`
`✅ Drafts created with Graph API and fallback to Outlook COM on Windows`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
