### PR TITLE
docs: add no-sync-between-manual-merges rule to git.md

### DIFF
--- a/.claude/skills/git.md
+++ b/.claude/skills/git.md
@@ -87,10 +87,15 @@ If stackit errors (e.g., "Pull request is in clean status", automerge failures):
    ```bash
    gh pr merge <PR-NUMBER> --merge --delete-branch
    ```
-4. **Immediately return to stackit** for cleanup and remaining merges:
+4. **Do NOT run `stackit sync` between manual merges.** GitHub retargets child PRs automatically when a base branch is merged+deleted. Running sync races with GitHub's retargeting and can cascade-close child PRs.
+5. Wait ~5s for GitHub to retarget, then merge the next PR the same way:
    ```bash
-   stackit sync --no-interactive     # Let stackit clean up and restack
-   stackit merge next --no-interactive  # Continue with next PR
+   sleep 5
+   gh pr merge <NEXT-PR-NUMBER> --merge --delete-branch
+   ```
+6. After **all** PRs are merged, run `stackit sync` once to clean up local branches:
+   ```bash
+   stackit sync --no-interactive
    ```
 
 **NEVER** do any of the following as "recovery":


### PR DESCRIPTION
## **User description**
## Summary by Sourcery

Documentation:
- Document a rule to avoid running `stackit sync` between manual merges of stacked PRs and to only sync once after all PRs are merged.


___

## **CodeAnt-AI Description**
Do not run stackit sync between manual merges; wait for GitHub retargeting and sync once at the end

### What Changed
- Adds a rule advising not to run `stackit sync` between manual merges because GitHub automatically retargets child PRs and running sync during that window can race with retargeting and cascade-close child PRs
- Replaces the previous immediate sync step with a simple sequence: wait ~5s, merge the next PR via GitHub, and only run `stackit sync --no-interactive` once after all PRs are merged to clean up local branches
- Removes the prior recommendation to return to stackit and sync between each manual merge

### Impact
`✅ Fewer cascade-closed PRs`
`✅ Clearer manual merge sequence`
`✅ Fewer accidental branch cleanup actions`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>