### PR TITLE
feat: remove task/subtask from NodeType enum and all consumers

### DIFF
--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -30,7 +30,6 @@ export {
   BulkDeleteInputSchema,
   SaveToLibraryInputSchema,
   ToggleCloneExcludedInputSchema,
-  CreateReferenceInputSchema,
   UpdateReferenceModeInputSchema,
   UpdateReferenceSnapshotInputSchema,
   BulkResolveInputSchema,
@@ -78,7 +77,7 @@ export interface HierarchyNodesTable {
   id: Generated<string>;
   parent_id: string | null;
   root_project_id: string | null;
-  type: 'project' | 'process' | 'stage' | 'subprocess' | 'task' | 'subtask' | 'template';
+  type: 'project' | 'process' | 'stage' | 'subprocess' | 'template';
   title: string;
   description: unknown | null; // TipTap JSON document
   position: Generated<number>;
@@ -131,26 +130,6 @@ export type DataRecord = Selectable<RecordsTable>;
 export type NewDataRecord = Insertable<RecordsTable>;
 export type DataRecordUpdate = Updateable<RecordsTable>;
 
-// Task References Table
-// DEPRECATED: Read-only after migration 022. Use ActionReferencesTable instead.
-// Kept for migration period traceability. Do not write new rows.
-export interface TaskReferencesTable {
-  id: Generated<string>;
-  task_id: string;
-  source_record_id: string | null;
-  target_field_key: string | null;
-  mode: Generated<'static' | 'dynamic'>;
-  snapshot_value: unknown | null; // JSONB
-  created_at: Generated<Date>;
-}
-
-/** @deprecated Use ActionReference instead */
-export type TaskReference = Selectable<TaskReferencesTable>;
-/** @deprecated Do not create new TaskReferences - use action_references */
-export type NewTaskReference = Insertable<TaskReferencesTable>;
-/** @deprecated TaskReferences are read-only */
-export type TaskReferenceUpdate = Updateable<TaskReferencesTable>;
-
 // Action References Table (Foundational Model)
 // Links Actions to Records - replaces TaskReferences
 export interface ActionReferencesTable {
@@ -161,7 +140,6 @@ export interface ActionReferencesTable {
   mode: Generated<'static' | 'dynamic'>;
   snapshot_value: unknown | null; // JSONB
   created_at: Generated<Date>;
-  legacy_task_reference_id: string | null; // Traceability back to deprecated task_references
 }
 
 export type ActionReference = Selectable<ActionReferencesTable>;
@@ -667,8 +645,6 @@ export interface Database {
   hierarchy_nodes: HierarchyNodesTable;
   record_definitions: RecordDefinitionsTable;
   records: RecordsTable;
-  /** @deprecated Read-only after migration 022 */
-  task_references: TaskReferencesTable;
   action_references: ActionReferencesTable;
   record_links: RecordLinksTable;
   record_aliases: RecordAliasesTable;

--- a/backend/src/modules/composer/composer.service.ts
+++ b/backend/src/modules/composer/composer.service.ts
@@ -204,7 +204,6 @@ export async function compose(
                 mode: ref.mode,
                 snapshotValue: ref.snapshot_value,
                 createdAt: ref.created_at,
-                legacyTaskReferenceId: ref.legacy_task_reference_id,
             }));
         }
 

--- a/backend/src/modules/exports/projectors/bfa-project.projector.ts
+++ b/backend/src/modules/exports/projectors/bfa-project.projector.ts
@@ -194,7 +194,7 @@ async function getProjectTasks(projectId: string, openOnly: boolean) {
         .selectFrom('hierarchy_nodes')
         .selectAll()
         .where('parent_id', '=', projectId)
-        .where('type', 'in', ['task', 'subprocess']);
+        .where('type', 'in', ['subprocess']);
 
     if (openOnly) {
         // Filter for non-completed tasks based on metadata status

--- a/backend/src/modules/hierarchy/hierarchy.schemas.ts
+++ b/backend/src/modules/hierarchy/hierarchy.schemas.ts
@@ -8,13 +8,7 @@ import { z } from 'zod';
  * Primary node type schema (stage removed from new creations).
  * Stage is demoted to projection-only - see projections module.
  */
-export const nodeTypeSchema = z.enum(['project', 'process', 'subprocess', 'task', 'subtask']);
-
-/**
- * Legacy node type schema (includes stage for read compatibility).
- * @deprecated Only use for reading existing data or migrations.
- */
-export const legacyNodeTypeSchema = z.enum(['project', 'process', 'stage', 'subprocess', 'task', 'subtask']);
+export const nodeTypeSchema = z.enum(['project', 'process', 'subprocess']);
 
 // ============================================================================
 // CREATE/UPDATE SCHEMAS
@@ -59,7 +53,6 @@ export const cloneNodeSchema = z.object({
 // ============================================================================
 
 export type NodeType = z.infer<typeof nodeTypeSchema>;
-export type LegacyNodeType = z.infer<typeof legacyNodeTypeSchema>;
 export type CreateNodeInput = z.infer<typeof createNodeSchema>;
 export type UpdateNodeInput = z.infer<typeof updateNodeSchema>;
 export type MoveNodeInput = z.infer<typeof moveNodeSchema>;

--- a/backend/src/modules/imports/monday/monday-domain-interpreter.ts
+++ b/backend/src/modules/imports/monday/monday-domain-interpreter.ts
@@ -378,8 +378,7 @@ function createSubitemFromNode(
         : undefined;
 
     const treatAs = boardConfig.settings?.treatSubitemsAs ?? 'child_actions';
-    const entityType: ImportPlanItem['entityType'] =
-        treatAs === 'subtasks' ? 'subtask' : 'action';
+    const entityType: ImportPlanItem['entityType'] = 'action';
 
     const { fieldRecordings, pendingLinks } = convertColumnValues(
         node.columnValues,

--- a/backend/src/modules/imports/services/import-classification.service.ts
+++ b/backend/src/modules/imports/services/import-classification.service.ts
@@ -216,9 +216,7 @@ export function generateClassificationsForConnectorItems(
                 return baseClassification;
 
             case 'action':
-            case 'task':
-            case 'subtask':
-                // Work items (actions, tasks, subtasks) are created as actions in the actions table
+                // Work items (actions) are created as actions in the actions table
                 baseClassification = {
                     itemTempId: item.tempId,
                     outcome: 'INTERNAL_WORK' as ClassificationOutcome,

--- a/backend/src/modules/imports/types.ts
+++ b/backend/src/modules/imports/types.ts
@@ -124,8 +124,8 @@ export interface ImportPlanItem {
     /** Parent container temp ID (optional for connector imports) */
     parentTempId?: string;
     metadata: Record<string, unknown>;
-    /** Entity type inferred from source (project, stage, action, task, subtask, record) */
-    entityType?: 'project' | 'stage' | 'action' | 'task' | 'subtask' | 'record' | 'template';
+    /** Entity type inferred from source (project, stage, action, record, template) */
+    entityType?: 'project' | 'stage' | 'action' | 'record' | 'template';
     /** Planned action for execution (optional for connector imports) */
     plannedAction?: {
         type: string;

--- a/backend/src/modules/interpreter/monday-interpreter.ts
+++ b/backend/src/modules/interpreter/monday-interpreter.ts
@@ -227,13 +227,13 @@ function inferEntityType(
                 return 'process' as ImportPlanItem['entityType'];
             }
 
-            // All other items are tasks
-            return 'task';
+            // All other items are actions
+            return 'action';
         }
 
         case 'subitem':
-            // Subitems are always tasks (the actual work)
-            return 'task';
+            // Subitems are always actions (the actual work)
+            return 'action';
 
         default:
             return 'record';

--- a/backend/src/modules/projections/presets/hierarchy-projection.ts
+++ b/backend/src/modules/projections/presets/hierarchy-projection.ts
@@ -107,17 +107,15 @@ function getTitleFromAction(action: ActionProjectionInput): string {
  */
 function deriveNodeType(
     action: ActionProjectionInput
-): 'task' | 'subtask' | 'project' | 'process' | 'subprocess' {
+): 'project' | 'process' | 'subprocess' {
     const type = action.type.toLowerCase();
 
-    if (type === 'subtask') return 'subtask';
-    if (type === 'task') return 'task';
     if (type === 'subprocess') return 'subprocess';
     if (type === 'process') return 'process';
     if (type === 'project') return 'project';
 
-    // Default to task for unknown action types
-    return 'task';
+    // Default to subprocess for unknown action types
+    return 'subprocess';
 }
 
 // ============================================================================

--- a/frontend/src/api/hooks/imports.ts
+++ b/frontend/src/api/hooks/imports.ts
@@ -35,8 +35,8 @@ export interface ImportPlanItem {
     /** Parent container or item temp ID (optional for top-level items) */
     parentTempId?: string;
     metadata: Record<string, unknown>;
-    /** Entity type inferred from source (project, process, stage, subprocess, task, subtask, record, template) */
-    entityType?: 'project' | 'process' | 'stage' | 'subprocess' | 'action' | 'task' | 'subtask' | 'record' | 'template';
+    /** Entity type inferred from source (project, process, stage, subprocess, action, record, template) */
+    entityType?: 'project' | 'process' | 'stage' | 'subprocess' | 'action' | 'record' | 'template';
     /** Planned action for execution (optional for connector imports) */
     plannedAction?: {
         type: string;

--- a/frontend/src/api/hooks/operations/imports.ts
+++ b/frontend/src/api/hooks/operations/imports.ts
@@ -27,7 +27,7 @@ export interface ImportPlanItem {
     title: string;
     parentTempId?: string;
     metadata: Record<string, unknown>;
-    entityType?: 'project' | 'stage' | 'action' | 'task' | 'subtask' | 'record' | 'template';
+    entityType?: 'project' | 'stage' | 'action' | 'record' | 'template';
     plannedAction?: {
         type: string;
         payload: Record<string, unknown>;

--- a/frontend/src/overlay/types.ts
+++ b/frontend/src/overlay/types.ts
@@ -179,7 +179,7 @@ export interface CreateRecordContext {
 
 export interface CreateNodeContext {
     parentId: string;
-    nodeType: 'process' | 'stage' | 'subprocess' | 'task';
+    nodeType: 'process' | 'stage' | 'subprocess';
     /** Pre-resolved parent info */
     parent?: {
         id: string;

--- a/frontend/src/ui/composites/DataTableImport.tsx
+++ b/frontend/src/ui/composites/DataTableImport.tsx
@@ -594,7 +594,7 @@ function NestedLevel({
 
                             {/* Type cell */}
                             <div className="w-16 px-2 py-2 text-center">
-                                <EntityTypeBadge entityType={item.entityType || 'task'} />
+                                <EntityTypeBadge entityType={item.entityType || 'action'} />
                             </div>
 
                             {/* Field cells */}

--- a/frontend/src/ui/composites/IngestionView.tsx
+++ b/frontend/src/ui/composites/IngestionView.tsx
@@ -373,7 +373,6 @@ function getNodeIndent(type: string): number {
         case 'process': return 0;
         case 'stage': return 16;
         case 'subprocess': return 32;
-        case 'task': return 48;
         default: return 0;
     }
 }

--- a/frontend/src/ui/composites/MillerColumnsView.tsx
+++ b/frontend/src/ui/composites/MillerColumnsView.tsx
@@ -29,7 +29,6 @@ interface ColumnSelections {
     process: string | null;
     stage: string | null;
     subprocess: string | null;
-    task: string | null;
 }
 
 // ==================== MILLER COLUMNS VIEW ====================
@@ -44,7 +43,6 @@ export function MillerColumnsView({ className }: MillerColumnsViewProps) {
         process: null,
         stage: null,
         subprocess: null,
-        task: null,
     });
 
     // Derive full selections with project from store
@@ -64,7 +62,6 @@ export function MillerColumnsView({ className }: MillerColumnsViewProps) {
                     process: null,
                     stage: null,
                     subprocess: null,
-                    task: null,
                 });
             });
         }
@@ -94,10 +91,6 @@ export function MillerColumnsView({ className }: MillerColumnsViewProps) {
         () => (selections.stage ? getChildren(selections.stage) : []),
         [selections.stage, getChildren]
     );
-    const tasks = useMemo(
-        () => (selections.subprocess ? getChildren(selections.subprocess) : []),
-        [selections.subprocess, getChildren]
-    );
 
     const handleSelect = (level: NodeType, id: string) => {
         const node = getNode(id);
@@ -112,25 +105,18 @@ export function MillerColumnsView({ className }: MillerColumnsViewProps) {
                 newUserSelections.process = null;
                 newUserSelections.stage = null;
                 newUserSelections.subprocess = null;
-                newUserSelections.task = null;
                 break;
             case 'process':
                 newUserSelections.process = id;
                 newUserSelections.stage = null;
                 newUserSelections.subprocess = null;
-                newUserSelections.task = null;
                 break;
             case 'stage':
                 newUserSelections.stage = id;
                 newUserSelections.subprocess = null;
-                newUserSelections.task = null;
                 break;
             case 'subprocess':
                 newUserSelections.subprocess = id;
-                newUserSelections.task = null;
-                break;
-            case 'task':
-                newUserSelections.task = id;
                 break;
         }
 
@@ -150,7 +136,6 @@ export function MillerColumnsView({ className }: MillerColumnsViewProps) {
     const handleAddProcess = () => selections.project && openOverlay('create-node', { parentId: selections.project, nodeType: 'process' });
     const handleAddStage = () => selections.process && openOverlay('create-node', { parentId: selections.process, nodeType: 'stage' });
     const handleAddSubprocess = () => selections.stage && openOverlay('create-node', { parentId: selections.stage, nodeType: 'subprocess' });
-    const handleAddTask = () => selections.subprocess && openOverlay('create-node', { parentId: selections.subprocess, nodeType: 'task' });
 
     return (
         <div
@@ -209,17 +194,6 @@ export function MillerColumnsView({ className }: MillerColumnsViewProps) {
                     />
                 )}
 
-                {/* Column 5: Tasks (if subprocess selected) */}
-                {selections.subprocess && (
-                    <MillerColumn
-                        type="task"
-                        items={tasks}
-                        selectedId={selections.task}
-                        onSelect={(id) => handleSelect('task', id)}
-                        onAdd={handleAddTask}
-                        hasChildren={() => false}
-                    />
-                )}
             </div>
         </div>
     );

--- a/frontend/src/ui/composites/ProjectView.tsx
+++ b/frontend/src/ui/composites/ProjectView.tsx
@@ -155,7 +155,6 @@ export function ProjectView({ projectId, className }: ProjectViewProps) {
     const activeSubprocessId = useMemo(() => {
         if (!selectedNode) return subprocesses[0]?.id || null;
         if (selectedNode.type === 'subprocess') return selectedNode.id;
-        if (selectedNode.type === 'task') return selectedNode.parent_id;
         return subprocesses[0]?.id || null;
     }, [selectedNode, subprocesses]);
 
@@ -176,7 +175,7 @@ export function ProjectView({ projectId, className }: ProjectViewProps) {
 
     const tasks = useMemo(() => {
         if (!activeSubprocessId) return [];
-        return getChildren(activeSubprocessId).filter((n) => n.type === 'task');
+        return getChildren(activeSubprocessId);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [activeSubprocessId, getChildren, storeNodes]);
 

--- a/frontend/src/ui/composites/RecordPropertiesView.tsx
+++ b/frontend/src/ui/composites/RecordPropertiesView.tsx
@@ -83,8 +83,6 @@ export function RecordPropertiesView({ itemId, isNode }: RecordPropertiesViewPro
         const metadata: Record<string, unknown> =
             typeof rawMetadata === 'string' ? JSON.parse(rawMetadata) : rawMetadata;
 
-        const nodeType = node.type;
-
         // Find the definition for this node type
         const nodeTypeName = node.type.charAt(0).toUpperCase() + node.type.slice(1);
         const definition = definitions?.find((d) => {
@@ -94,22 +92,7 @@ export function RecordPropertiesView({ itemId, isNode }: RecordPropertiesViewPro
             return d.name === nodeTypeName;
         });
 
-        // Special handling for tasks
-        if (nodeType === 'task') {
-            const taskDef = definitions?.find((d) => d.name === 'Task');
-            const taskFieldKeys = taskDef?.schema_config?.fields
-                ?.filter((f) => f.key !== 'title' && f.key !== 'description')
-                ?.map((f) => f.key) || [];
-
-            // Add any extra metadata keys that aren't in the definition
-            const extraKeys = Object.keys(metadata).filter(
-                (key) => key !== 'percentComplete' && !taskFieldKeys.includes(key)
-            );
-
-            return [...taskFieldKeys, ...extraKeys];
-        }
-
-        // For other node types with definition
+        // For node types with definition
         if (definition?.schema_config?.fields) {
             return definition.schema_config.fields.map((f) => f.key);
         }

--- a/frontend/src/ui/layout/MillerColumn.tsx
+++ b/frontend/src/ui/layout/MillerColumn.tsx
@@ -17,8 +17,6 @@ const COLUMN_CONFIG: Record<NodeType, { label: string; badge: string; bgColor: s
   process: { label: 'Methodology', badge: 'M', bgColor: 'bg-purple-100', textColor: 'text-purple-600' },
   stage: { label: 'Stages', badge: 'F', bgColor: 'bg-yellow-100', textColor: 'text-yellow-600' },
   subprocess: { label: 'Subprocesses', badge: 'S', bgColor: 'bg-orange-100', textColor: 'text-orange-600' },
-  task: { label: 'Tasks', badge: 'T', bgColor: 'bg-slate-200', textColor: 'text-slate-600' },
-  subtask: { label: 'Subtasks', badge: 'ST', bgColor: 'bg-teal-100', textColor: 'text-teal-600' },
   template: { label: 'Templates', badge: 'TP', bgColor: 'bg-pink-100', textColor: 'text-pink-600' },
 };
 
@@ -77,7 +75,7 @@ export function MillerColumn({
               item={item}
               isSelected={item.id === selectedId}
               onClick={() => onSelect(item.id)}
-              showArrow={hasChildren ? hasChildren(item.id) : type !== 'task'}
+              showArrow={hasChildren ? hasChildren(item.id) : true}
             />
           ))
         )}

--- a/frontend/src/ui/layout/MillerColumnsView.tsx
+++ b/frontend/src/ui/layout/MillerColumnsView.tsx
@@ -12,7 +12,6 @@ interface ColumnSelections {
   process: string | null;
   stage: string | null;
   subprocess: string | null;
-  task: string | null;
 }
 
 export function MillerColumnsView() {
@@ -25,7 +24,6 @@ export function MillerColumnsView() {
     process: null,
     stage: null,
     subprocess: null,
-    task: null,
   });
 
   // Derive full selections with project from store
@@ -65,7 +63,6 @@ export function MillerColumnsView() {
           process: null,
           stage: null,
           subprocess: null,
-          task: null,
         });
       });
     }
@@ -95,7 +92,6 @@ export function MillerColumnsView() {
         newUserSelections.process = null;
         newUserSelections.stage = null;
         newUserSelections.subprocess = null;
-        newUserSelections.task = null;
         // Also set active project in UI store so other components know
         setActiveProject(id);
         break;
@@ -103,19 +99,13 @@ export function MillerColumnsView() {
         newUserSelections.process = id;
         newUserSelections.stage = null;
         newUserSelections.subprocess = null;
-        newUserSelections.task = null;
         break;
       case 'stage':
         newUserSelections.stage = id;
         newUserSelections.subprocess = null;
-        newUserSelections.task = null;
         break;
       case 'subprocess':
         newUserSelections.subprocess = id;
-        newUserSelections.task = null;
-        break;
-      case 'task':
-        newUserSelections.task = id;
         break;
     }
 
@@ -180,16 +170,6 @@ export function MillerColumnsView() {
           />
         )}
 
-        {/* Column 5: Tasks (if subprocess selected) */}
-        {selections.subprocess && (
-          <MillerColumn
-            type="task"
-            parentId={selections.subprocess}
-            selectedId={selections.task}
-            onSelect={(id) => handleSelect('task', id)}
-            hasChildren={() => false}
-          />
-        )}
       </div>
     </div>
   );

--- a/frontend/src/ui/layout/Workspace.tsx
+++ b/frontend/src/ui/layout/Workspace.tsx
@@ -183,22 +183,15 @@ interface SubprocessSectionProps {
 
 function SubprocessSection({ subprocess }: SubprocessSectionProps) {
   const { getChildren } = useHierarchyStore();
-  const { openOverlay } = useUIStore();
-  const tasks = getChildren(subprocess.id).filter(node => node.type === 'task');
+  const children = getChildren(subprocess.id);
 
   return (
     <div className="pl-4 border-l border-slate-200 ml-2 mt-4">
       <div className="flex items-center justify-between mb-3">
         <h4 className="text-lg font-bold text-slate-700">{subprocess.title}</h4>
-        <button
-          onClick={() => openOverlay('create-node', { parentId: subprocess.id, nodeType: 'task' })}
-          className="text-xs text-blue-600 hover:underline"
-        >
-          <Plus size={12} className="inline-block mr-1" /> Add Task
-        </button>
       </div>
       <div className="space-y-3">
-        {tasks.map((task) => (
+        {children.map((task) => (
           <TaskCard key={task.id} task={task} />
         ))}
       </div>
@@ -271,7 +264,7 @@ export function Workspace() {
     stages.forEach(stage => {
       const subprocesses = getChildren(stage.id).filter(node => node.type === 'subprocess');
       subprocesses.forEach(subprocess => {
-        tasks = tasks.concat(getChildren(subprocess.id).filter(node => node.type === 'task'));
+        tasks = tasks.concat(getChildren(subprocess.id));
       });
     });
     return tasks;

--- a/frontend/src/ui/molecules/MillerColumn.tsx
+++ b/frontend/src/ui/molecules/MillerColumn.tsx
@@ -98,8 +98,6 @@ const COLUMN_CONFIG: Record<NodeType, { label: string; badge: string; bgColor: s
     process: { label: 'Methodology', badge: 'M', bgColor: 'bg-purple-100', textColor: 'text-purple-600' },
     stage: { label: 'Stages', badge: 'F', bgColor: 'bg-yellow-100', textColor: 'text-yellow-600' },
     subprocess: { label: 'Subprocesses', badge: 'S', bgColor: 'bg-orange-100', textColor: 'text-orange-600' },
-    task: { label: 'Tasks', badge: 'T', bgColor: 'bg-slate-200', textColor: 'text-slate-600' },
-    subtask: { label: 'Subtasks', badge: 'ST', bgColor: 'bg-teal-100', textColor: 'text-teal-600' },
     template: { label: 'Templates', badge: 'TP', bgColor: 'bg-pink-100', textColor: 'text-pink-600' },
 };
 
@@ -172,7 +170,7 @@ function HierarchyColumn({
                             item={item}
                             isSelected={item.id === selectedId}
                             onClick={() => onSelect(item.id)}
-                            showArrow={hasChildren ? hasChildren(item.id) : type !== 'task'}
+                            showArrow={hasChildren ? hasChildren(item.id) : true}
                         />
                     ))
                 )}

--- a/frontend/src/ui/overlay/views/CreateRecordView.tsx
+++ b/frontend/src/ui/overlay/views/CreateRecordView.tsx
@@ -156,7 +156,7 @@ export function CreateRecordView(props: CreateRecordViewProps | LegacyCreateReco
     : null;
 
   const classifiableNodes = projectNodes?.filter((n) =>
-    ['project', 'subprocess', 'task'].includes(n.type)
+    ['project', 'subprocess'].includes(n.type)
   ) || [];
 
   const icon = definition.styling?.icon;

--- a/frontend/src/ui/sidebars/DefinitionListSidebar.tsx
+++ b/frontend/src/ui/sidebars/DefinitionListSidebar.tsx
@@ -50,12 +50,11 @@ export function DefinitionListSidebar({
             if (defKind) return defKind === 'record';
             // Fallback for missing kind: exclude hierarchy and known actions
             const name = def.name.toLowerCase();
-            return !legacyHierarchyTypes.includes(name) && name !== 'task' && name !== 'subtask';
+            return !legacyHierarchyTypes.includes(name);
         } else {
             if (defKind) return defKind === 'action_arrangement';
-            // Fallback: check known action names
-            const name = def.name.toLowerCase();
-            return name === 'task' || name === 'subtask';
+            // No fallback heuristic - require explicit kind
+            return false;
         }
     });
 

--- a/frontend/src/ui/sidebars/RegistrySidebar.tsx
+++ b/frontend/src/ui/sidebars/RegistrySidebar.tsx
@@ -59,7 +59,7 @@ export function RegistrySidebar({
         const defKind = (def as { definition_kind?: string }).definition_kind;
         if (defKind) return defKind === 'record';
         const name = def.name.toLowerCase();
-        return !legacyHierarchyTypes.includes(name) && name !== 'task' && name !== 'subtask';
+        return !legacyHierarchyTypes.includes(name);
     });
 
     // Apply search filter

--- a/frontend/src/ui/table-core/adapters/ImportPlanRowModelAdapter.ts
+++ b/frontend/src/ui/table-core/adapters/ImportPlanRowModelAdapter.ts
@@ -73,7 +73,7 @@ function buildImportTree(plan: ImportPlan): ImportPlanNode[] {
         const mondayMeta = item.metadata?.monday as { type?: string } | undefined;
         const entityType = (item as { entityType?: string }).entityType
             ?? mondayMeta?.type
-            ?? 'task';
+            ?? 'action';
 
         nodeMap.set(item.tempId, {
             id: item.tempId,
@@ -176,7 +176,7 @@ export function getImportPlanMeta(row: TableRow): ImportPlanRowMeta {
         hasChildren: (meta.hasChildren as boolean) ?? false,
         isExpanded: (meta.isExpanded as boolean) ?? false,
         nodeType: (meta.nodeType as 'container' | 'item') ?? 'item',
-        entityType: (meta.entityType as string) ?? 'task',
+        entityType: (meta.entityType as string) ?? 'action',
         classification: meta.classification as ItemClassification | undefined,
     };
 }

--- a/frontend/src/utils/gantt-task-adapter.ts
+++ b/frontend/src/utils/gantt-task-adapter.ts
@@ -137,14 +137,14 @@ export function renderHierarchy(
 
     // Group by type for hierarchy
     const subprocesses = children.filter(n => n.type === 'subprocess');
-    const taskNodes = children.filter(n => n.type === 'task');
-    const tasksBySubprocess = new Map<string, HierarchyNode[]>();
+    const nonSubprocessNodes = children.filter(n => n.type !== 'subprocess' && n.type !== 'process' && n.type !== 'stage' && n.type !== 'project');
+    const nodesBySubprocess = new Map<string, HierarchyNode[]>();
 
-    taskNodes.forEach(t => {
+    nonSubprocessNodes.forEach(t => {
         if (t.parent_id) {
-            const list = tasksBySubprocess.get(t.parent_id) || [];
+            const list = nodesBySubprocess.get(t.parent_id) || [];
             list.push(t);
-            tasksBySubprocess.set(t.parent_id, list);
+            nodesBySubprocess.set(t.parent_id, list);
         }
     });
 
@@ -169,7 +169,7 @@ export function renderHierarchy(
         start: projectDates.start,
         end: projectDates.end,
         type: 'lane',
-        progress: calculateProgress(taskNodes),
+        progress: calculateProgress(nonSubprocessNodes),
         hideChildren: false,
         sourceType: 'node',
         styles: {
@@ -182,7 +182,7 @@ export function renderHierarchy(
 
     // Add subprocesses as lane groups
     subprocesses.forEach(sp => {
-        const spItems = tasksBySubprocess.get(sp.id) || [];
+        const spItems = nodesBySubprocess.get(sp.id) || [];
         const spDates = extractDates(sp.metadata, spItems);
         trackDates(spDates);
 

--- a/shared/src/schemas/enums.ts
+++ b/shared/src/schemas/enums.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
  * Includes the 5-level project hierarchy plus subtask for nested tasks
  * and template for hierarchy-agnostic singleton records
  */
-export const NodeTypeSchema = z.enum(['project', 'process', 'stage', 'subprocess', 'task', 'subtask', 'template']);
+export const NodeTypeSchema = z.enum(['project', 'process', 'stage', 'subprocess', 'template']);
 export type NodeType = z.infer<typeof NodeTypeSchema>;
 
 /**


### PR DESCRIPTION
## **User description**
- Remove 'task' and 'subtask' from NodeTypeSchema in shared/enums.ts
- Remove task/subtask from HierarchyNodesTable type union in db/schema.ts
- Delete TaskReferencesTable interface and type aliases from db/schema.ts
- Remove legacy_task_reference_id from ActionReferencesTable
- Remove task/subtask from VALID_PARENTS and DEPTH_LIMITS
- Remove legacyNodeTypeSchema from hierarchy.schemas.ts
- Remove task/subtask cases from import classification, monday interpreter,
  hierarchy projection, and BFA projector
- Remove task column from both MillerColumnsView components
- Remove Add Task/Subtask buttons from ProjectWorkflowView
- Remove task node type filtering from Workspace, ProjectView, gantt adapter
- Clean up RecordPropertiesView, CreateRecordView, import adapters
- Remove task/subtask from frontend type unions and entity type enums

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

## Summary by Sourcery

Remove task/subtask node types across shared schemas, backend services, and frontend experiences to finalize the hierarchy simplification.

Enhancements:
- Prune task/subtask entries from hierarchy schemas, database types, depth limits, and import/export pipelines so only the remaining node types are modeled.
- Simplify UI surfaces (workflow view, Miller columns, workspace, project view, overlays, registry/definition sidebars, import tables, gantt adapter) by eliminating task-specific controls, filters, and metadata handling.


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #285**
  * **PR #282**
    * **PR #283** 👈
      * **PR #284**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Remove 'task' and 'subtask' node types from API, database, import/export, and UI

### What Changed
- New node creation and APIs no longer accept "task" or "subtask"; only project/process/stage/subprocess/template are valid for new nodes
- UI surfaces removed task/subtask controls: "Add Task/Subtask" buttons, task column in Miller view, task-specific filters and task-only badges are gone; lists and columns now show subprocesses and regular records instead
- Imports and Monday connector now treat subitems/tasks as actions (not separate task/subtask nodes); import previews and import rows default to "action"
- Database schema and backend projections removed deprecated task_references table and legacy task reference fields from action responses; hierarchy queries and projections no longer return or expect task/subtask types

### Impact
`✅ Shorter node creation (no task/subtask option)`
`✅ Clearer import mapping for subitems → actions`
`✅ Fewer UI controls and filters related to deprecated task types`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
