### PR TITLE
feat: add export output storage migration and persistence layer

### DIFF
--- a/backend/src/db/migrations/048_export_output_storage.ts
+++ b/backend/src/db/migrations/048_export_output_storage.ts
@@ -1,0 +1,56 @@
+/**
+ * Migration 048: Export Output Storage
+ *
+ * Expands the export_sessions format CHECK constraint to include
+ * 'pdf' and 'docx' formats, and adds columns for storing
+ * generated output files (path + MIME type).
+ */
+
+import type { Kysely } from 'kysely';
+import { sql } from 'kysely';
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+    // Drop existing constraint and add updated one with all 9 formats
+    await sql`
+        ALTER TABLE export_sessions
+        DROP CONSTRAINT IF EXISTS export_sessions_format_check;
+    `.execute(db);
+
+    await sql`
+        ALTER TABLE export_sessions
+        ADD CONSTRAINT export_sessions_format_check
+        CHECK (format IN (
+            'rtf', 'markdown', 'plaintext', 'csv',
+            'google-doc', 'google-sheets', 'google-slides',
+            'pdf', 'docx'
+        ));
+    `.execute(db);
+
+    // Add output storage columns
+    await sql`
+        ALTER TABLE export_sessions
+        ADD COLUMN output_path TEXT,
+        ADD COLUMN output_mime_type TEXT;
+    `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+    // Remove output storage columns
+    await sql`
+        ALTER TABLE export_sessions
+        DROP COLUMN IF EXISTS output_path,
+        DROP COLUMN IF EXISTS output_mime_type;
+    `.execute(db);
+
+    // Restore previous constraint (7 formats, no pdf/docx)
+    await sql`
+        ALTER TABLE export_sessions
+        DROP CONSTRAINT IF EXISTS export_sessions_format_check;
+    `.execute(db);
+
+    await sql`
+        ALTER TABLE export_sessions
+        ADD CONSTRAINT export_sessions_format_check
+        CHECK (format IN ('rtf', 'markdown', 'plaintext', 'csv', 'google-doc', 'google-sheets', 'google-slides'));
+    `.execute(db);
+}

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -407,6 +407,8 @@ export interface ExportSessionsTable {
   target_config: Generated<unknown>; // JSONB
   projection_cache: unknown | null; // JSONB
   output_url: string | null;
+  output_path: string | null;
+  output_mime_type: string | null;
   error: string | null;
   created_by: string | null;
   created_at: Generated<Date>;

--- a/backend/src/modules/exports/exports.service.ts
+++ b/backend/src/modules/exports/exports.service.ts
@@ -479,6 +479,8 @@ function mapDbToSession(row: {
     target_config: unknown | null;
     status: string;
     projection_cache: unknown | null;
+    output_path: string | null;
+    output_mime_type: string | null;
     error: string | null;
     created_by: string | null;
     created_at: Date;
@@ -498,6 +500,8 @@ function mapDbToSession(row: {
         targetConfig: row.target_config ? parseJsonb<Record<string, unknown>>(row.target_config) : undefined,
         status: row.status as ExportSessionStatus,
         projectionCache: row.projection_cache ? parseJsonb<BfaProjectExportModel[]>(row.projection_cache) : undefined,
+        outputPath: row.output_path ?? undefined,
+        outputMimeType: row.output_mime_type ?? undefined,
         error: row.error ?? undefined,
         createdBy: row.created_by ?? undefined,
         createdAt: row.created_at.toISOString(),

--- a/backend/src/modules/exports/index.ts
+++ b/backend/src/modules/exports/index.ts
@@ -7,6 +7,7 @@
 
 // Service exports
 export * from './exports.service.js';
+export * from './output-store.js';
 
 // Routes
 export { exportsRoutes } from './exports.routes.js';

--- a/backend/src/modules/exports/output-store.ts
+++ b/backend/src/modules/exports/output-store.ts
@@ -1,0 +1,120 @@
+/**
+ * Output Store
+ *
+ * File-based storage for export session output artifacts.
+ * Stores generated files (PDF, DOCX, etc.) and provides
+ * retrieval for the download endpoint.
+ */
+
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { db } from '../../db/client.js';
+
+const EXPORT_OUTPUT_DIR = process.env.EXPORT_OUTPUT_DIR
+    || path.join(os.tmpdir(), 'autoart-exports');
+
+/**
+ * Store a session's generated output to disk and record the path in the database.
+ */
+export async function storeSessionOutput(
+    sessionId: string,
+    buffer: Buffer,
+    mimeType: string,
+    extension: string,
+): Promise<string> {
+    const dir = path.join(EXPORT_OUTPUT_DIR, 'exports');
+    await fs.mkdir(dir, { recursive: true });
+
+    const filename = `${sessionId}${extension}`;
+    const filePath = path.join(dir, filename);
+
+    await fs.writeFile(filePath, buffer);
+
+    // Persist path and MIME type on the session row
+    await db
+        .updateTable('export_sessions')
+        .set({
+            output_path: filePath,
+            output_mime_type: mimeType,
+            updated_at: new Date(),
+        })
+        .where('id', '=', sessionId)
+        .execute();
+
+    return filePath;
+}
+
+/**
+ * Retrieve a session's stored output from disk.
+ * Returns null if no output has been stored.
+ */
+export async function getSessionOutput(
+    sessionId: string,
+): Promise<{ buffer: Buffer; mimeType: string; filename: string } | null> {
+    const row = await db
+        .selectFrom('export_sessions')
+        .select(['output_path', 'output_mime_type', 'format', 'status'])
+        .where('id', '=', sessionId)
+        .executeTakeFirst();
+
+    if (!row?.output_path || !row.output_mime_type) return null;
+
+    try {
+        const buffer = await fs.readFile(row.output_path);
+        const ext = path.extname(row.output_path);
+        const filename = `export-${sessionId.slice(0, 8)}${ext}`;
+
+        return {
+            buffer,
+            mimeType: row.output_mime_type,
+            filename,
+        };
+    } catch {
+        // File missing from disk — stale reference
+        return null;
+    }
+}
+
+/**
+ * Remove output files older than maxAgeMs.
+ * Returns the number of files cleaned up.
+ */
+export async function cleanupExpiredOutputs(maxAgeMs: number): Promise<number> {
+    const cutoff = new Date(Date.now() - maxAgeMs);
+
+    const expired = await db
+        .selectFrom('export_sessions')
+        .select(['id', 'output_path'])
+        .where('output_path', 'is not', null)
+        .where('created_at', '<', cutoff)
+        .execute();
+
+    let cleaned = 0;
+    for (const row of expired) {
+        if (!row.output_path) continue;
+        try {
+            await fs.unlink(row.output_path);
+            cleaned++;
+        } catch {
+            // File already gone — ignore
+        }
+    }
+
+    // Clear the path references
+    if (expired.length > 0) {
+        const ids = expired.map((r) => r.id);
+        await db
+            .updateTable('export_sessions')
+            .set({
+                output_path: null,
+                output_mime_type: null,
+                updated_at: new Date(),
+            })
+            .where('id', 'in', ids)
+            .execute();
+    }
+
+    return cleaned;
+}

--- a/shared/src/schemas/exports.ts
+++ b/shared/src/schemas/exports.ts
@@ -12,7 +12,7 @@ import { z } from 'zod';
 // EXPORT FORMATS
 // ============================================================================
 
-/** Must match database CHECK constraint in migration 033/034/035 */
+/** Must match database CHECK constraint in migration 033/034/048 */
 export const ExportFormatSchema = z.enum([
     'rtf',
     'plaintext',
@@ -22,6 +22,7 @@ export const ExportFormatSchema = z.enum([
     'google-sheets',
     'google-slides',
     'pdf',
+    'docx',
     // Note: Gantt is not an export format - it's a projection type that uses PDF format
 ]);
 export type ExportFormat = z.infer<typeof ExportFormatSchema>;
@@ -94,7 +95,7 @@ export type FinanceExportPreset = 'invoice-pdf' | 'invoice-docx' | 'budget-csv' 
 export const FINANCE_EXPORT_PRESETS: Record<FinanceExportPreset, {
     label: string;
     description: string;
-    format: ExportFormat | 'docx';
+    format: ExportFormat;
 }> = {
     'invoice-pdf': {
         label: 'Invoice PDF',
@@ -215,6 +216,8 @@ export const ExportSessionSchema = z.object({
     options: ExportOptionsSchema,
     status: ExportSessionStatusSchema,
     projectionCache: z.array(BfaProjectExportModelSchema).optional(),
+    outputPath: z.string().optional(),
+    outputMimeType: z.string().optional(),
     error: z.string().optional(),
     createdBy: z.string().optional(),
     createdAt: z.string(),

--- a/todo.md
+++ b/todo.md
@@ -12,9 +12,8 @@
 
 | # | Issue | Category |
 |---|-------|----------|
-| — | Polls: no editor/management surface in dashboard — only public response UI exists | Feature |
+| 275 | Epic: Export Workbench — preview-first outputs + finance templates via sessions | Epic |
 | — | Autohelper: add auth key handshake between frontend settings and backend | Security |
-| 218 | Phase 6: Remove task_references system + hierarchy nodes | Refactor |
 | 217 | Expose interpretation HTTP routes for frontend hooks | Backend |
 | 216 | Derived field: "Last Updated / Last Touched" with Project Log linkage | Feature |
 | 235 | Add Context Breadcrumb to Events | Frontend |
@@ -28,6 +27,7 @@
 
 | # | Issue | Category |
 |---|-------|----------|
+| 173 | Epic: Finance Management System (Invoices + Budgets + Vendor Bills + Reconciliation) | Epic |
 | 181 | Fix workspace preset timing (pendingPanelPositions) | Bug |
 | 182 | Workspace modification tracking and save workflow | Workspace |
 | 180 | Add route/project context to workspace system | Workspace |
@@ -63,12 +63,7 @@
 
 ## In-Flight (Awaiting Review)
 
-| PR | Description |
-|----|-------------|
-| #270 | docs: drop --delete-branch from manual merge fallback in git.md |
-| #266 | docs: add no-sync-between-manual-merges rule to git.md |
-| #261 | refactor: replace hardcoded font-family with CSS variables |
-| #260 | refactor: extract shared font base.css for all three builds |
+*(none)*
 
 ---
 
@@ -76,22 +71,18 @@
 
 | # | Issue | Closed By |
 |---|-------|-----------|
+| 218 | Phase 6: Remove task_references system + hierarchy nodes | PRs #282-285 |
+| — | Polls editor/management surface in dashboard | PRs #271-273 |
+| — | Style token infrastructure + formatter consumption | PRs #279-280 |
+| — | Chladni-pattern cymatic loading screen | PR #281 |
+| — | In-flight doc PRs (git.md merge rules) | PRs #266, #270 |
+| — | Font refactor: shared base.css + CSS variable font-family | PRs #260, #262 |
 | — | Dockview panels not rendering + Composer defaults to "Task" | PRs #263-265 |
-| — | Header reorder, Applications dropdown, Intake cleanup, parchment accent darkened | PRs #267, #269 |
+| — | Header reorder, Applications dropdown, Intake cleanup | PRs #267, #269 |
 | — | Restore Windows venv scripts | PR #259 |
-| — | Streamline CLAUDE.md | PR #257 |
-| — | Autohelper platform detection + review fixes | PRs #255, #256 |
-| — | Resolve all frontend and mail type errors | PR #250 |
-| — | Resolve all 92 backend ESLint errors | PR #252 |
 | 238 | Epic: Invoicerr Integration (invoice management system) | PRs #239-249 |
-| — | Architecture docs update (Jan 2026) | PR #236 |
-| — | BFA projector deep query + RTF formatter fidelity + section alignment | PRs #224-226 |
-| — | Wire ActionsPanel to open ComposerPanel | PR #220 |
 | 227-234 | Events Module + Project Log (Phases 1-4) | PRs #227-234 |
-| 44 | Google OAuth integration is cosmetic | PRs #221-223 |
 | 185 | Fork and modernize crab-meet scheduling polls | PRs #186, #206-213 |
-| 193 | Polls UI: migrate to @autoart/ui primitives | PR #207 |
-| 111-113 | Time/calendar features (duration sidechain, working-days, hot zones) | Closed 2026-01-25 |
 | 87 | Global Command Palette | PRs #174, #176 |
 
 ---


### PR DESCRIPTION
## **User description**
- Migration 048: expand format CHECK to add pdf/docx, add output_path + output_mime_type columns
- New output-store.ts service (storeSessionOutput, getSessionOutput, cleanupExpiredOutputs)
- New GET /sessions/:id/output download route with Content-Disposition support
- Update schema.ts with new columns, mapDbToSession with new fields
- Add docx to ExportFormatSchema, fix FINANCE_EXPORT_PRESETS type

Refs #276

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

## Summary by Sourcery

Add persistent storage and retrieval for export session output artifacts, including new formats and a download endpoint.

New Features:
- Support pdf and docx as export formats across backend and shared schemas.
- Introduce a file-based output store for export sessions, with APIs to store, retrieve, and clean up generated files.
- Expose a GET /sessions/:id/output endpoint to download completed export artifacts with configurable Content-Disposition.

Enhancements:
- Extend export session model and database schema with output path and MIME type fields to track stored artifacts.
- Tighten finance export presets typing by requiring formats to use the shared ExportFormat enum.

Documentation:
- Update todo tracking to reflect new export and finance epics and recently closed PRs.


___

## **CodeAnt-AI Description**
Add persistent output storage for export sessions and a downloadable endpoint

### What Changed
- Export sessions can now produce and store PDF and DOCX artifacts; the export format list and finance presets include these formats
- Completed export artifacts are saved to disk and the session records store the file path and MIME type so outputs can be retrieved later
- A new GET /sessions/:id/output endpoint lets users download a session's generated file with configurable Content-Disposition (inline or attachment)
- A cleanup utility removes old stored export files and clears their session references to avoid stale disk entries
- Database migration adds output_path and output_mime_type columns and updates the format constraint to include pdf and docx

### Impact
`✅ Can download exported PDF/DOCX`
`✅ Export artifacts persist after generation for later retrieval`
`✅ Automatic removal of stale export files to avoid disk buildup`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #286** 👈
  * **PR #287**
    * **PR #288**
      * **PR #289**
        * **PR #290**
          * **PR #292**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->