### PR TITLE
feat: wire PDF + DOCX into session execution with BFA DOCX formatter

### DIFF
--- a/frontend/src/workflows/export/types.ts
+++ b/frontend/src/workflows/export/types.ts
@@ -79,8 +79,14 @@ export const EXPORT_FORMATS: ExportFormatOption[] = [
     {
         id: 'pdf',
         label: 'PDF Document',
-        description: 'Export to portable document format',
+        description: 'PDF document (via AutoHelper)',
         extension: '.pdf',
+    },
+    {
+        id: 'docx',
+        label: 'Word Document',
+        description: 'Word .docx document',
+        extension: '.docx',
     },
     // NOTE: Gantt export is triggered directly from TimelineWrapper panel,
     // not through ExportWorkbench. Re-enable when batch workflow is added.

--- a/shared/src/formatters/bfa-docx-formatter.ts
+++ b/shared/src/formatters/bfa-docx-formatter.ts
@@ -1,0 +1,312 @@
+/**
+ * BFA DOCX Formatter
+ *
+ * Generates a Word document from BfaProjectExportModel[] using the `docx` package.
+ * Uses Parchment design system tokens (Source Serif 4 + IBM Plex Mono).
+ *
+ * Sections per project: header, contacts, timeline, selection panel, status, next steps.
+ * Projects grouped by category (PUBLIC ART, CORPORATE, PRIVATE / CORPORATE).
+ *
+ * Returns a `docx.Document` object. Caller serializes with `Packer.toBuffer()`.
+ */
+
+import {
+    Document,
+    Paragraph,
+    TextRun,
+    AlignmentType,
+    BorderStyle,
+} from 'docx';
+
+import type { BfaProjectExportModel, ExportOptions } from '../schemas/exports.js';
+import { compileDocxStyles } from './compile-docx-styles.js';
+import { PARCHMENT_TOKENS } from './style-tokens.js';
+
+// ============================================================================
+// COMPILED TOKENS
+// ============================================================================
+
+const S = compileDocxStyles(PARCHMENT_TOKENS);
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+function serifRun(text: string, options?: { bold?: boolean; size?: number; color?: string }): TextRun {
+    return new TextRun({
+        text,
+        font: { name: S.fonts.primary, hint: undefined },
+        size: options?.size ?? S.sizes.body,
+        bold: options?.bold,
+        color: options?.color ?? S.colors.text,
+    });
+}
+
+function monoRun(text: string, options?: { size?: number; color?: string }): TextRun {
+    return new TextRun({
+        text,
+        font: { name: S.fonts.mono, hint: undefined },
+        size: options?.size ?? S.sizes.mono,
+        color: options?.color ?? S.colors.textSecondary,
+    });
+}
+
+function labelRun(text: string): TextRun {
+    return new TextRun({
+        text,
+        font: { name: S.fonts.primary, hint: undefined },
+        size: S.sizes.meta,
+        color: S.colors.accentSecondary,
+        allCaps: true,
+        bold: true,
+    });
+}
+
+// ============================================================================
+// DOCUMENT BUILDER
+// ============================================================================
+
+/**
+ * Generate a BFA To-Do DOCX document.
+ */
+export function generateBfaDocx(
+    projects: BfaProjectExportModel[],
+    options: ExportOptions,
+): Document {
+    const publicProjects = projects.filter((p) => p.category === 'public');
+    const corporateProjects = projects.filter((p) => p.category === 'corporate');
+    const privateProjects = projects.filter((p) => p.category === 'private_corporate');
+
+    const children: Paragraph[] = [];
+
+    // Document title
+    children.push(
+        new Paragraph({
+            children: [serifRun('BFA To-Do List', { bold: true, size: S.sizes.h1 })],
+            spacing: { after: 80 },
+        }),
+        new Paragraph({
+            children: [monoRun(`Generated: ${new Date().toLocaleDateString('en-CA')}`)],
+            spacing: { after: 300 },
+        }),
+    );
+
+    if (publicProjects.length > 0) {
+        children.push(categoryHeading('Public Art'));
+        for (const project of publicProjects) {
+            children.push(...formatProject(project, options));
+        }
+    }
+
+    if (corporateProjects.length > 0) {
+        children.push(categoryHeading('Corporate'));
+        for (const project of corporateProjects) {
+            children.push(...formatProject(project, options));
+        }
+    }
+
+    if (privateProjects.length > 0) {
+        children.push(categoryHeading('Private / Corporate'));
+        for (const project of privateProjects) {
+            children.push(...formatProject(project, options));
+        }
+    }
+
+    return new Document({
+        styles: {
+            default: {
+                document: {
+                    run: S.defaultRun,
+                    paragraph: S.defaultParagraph,
+                },
+            },
+        },
+        sections: [
+            {
+                properties: {
+                    page: {
+                        margin: {
+                            top: S.pageMarginTwip,
+                            right: S.pageMarginTwip,
+                            bottom: S.pageMarginTwip,
+                            left: S.pageMarginTwip,
+                        },
+                    },
+                },
+                children,
+            },
+        ],
+    });
+}
+
+// ============================================================================
+// SECTIONS
+// ============================================================================
+
+function categoryHeading(label: string): Paragraph {
+    return new Paragraph({
+        children: [serifRun(label.toUpperCase(), { bold: true, size: S.sizes.h2, color: S.colors.accent })],
+        spacing: { before: 400, after: 200 },
+        border: {
+            bottom: { style: BorderStyle.SINGLE, size: 1, color: S.colors.border },
+        },
+    });
+}
+
+function formatProject(project: BfaProjectExportModel, options: ExportOptions): Paragraph[] {
+    const parts: Paragraph[] = [];
+
+    // Header line
+    parts.push(new Paragraph({
+        children: [serifRun(formatHeaderLine(project), { bold: true })],
+        spacing: { before: 240, after: 80 },
+    }));
+
+    // Contacts
+    if (options.includeContacts && project.contactsBlock.lines.length > 0) {
+        parts.push(new Paragraph({
+            children: [labelRun('Contacts')],
+            spacing: { before: 80, after: 40 },
+        }));
+        for (const line of project.contactsBlock.lines) {
+            parts.push(new Paragraph({
+                children: [serifRun(line, { size: S.sizes.meta, color: S.colors.textSecondary })],
+                indent: { left: 216 },
+            }));
+        }
+    }
+
+    // Timeline
+    if (options.includeMilestones && project.timelineBlock.milestones.length > 0) {
+        parts.push(new Paragraph({
+            children: [labelRun('Timeline')],
+            spacing: { before: 80, after: 40 },
+        }));
+        for (const milestone of project.timelineBlock.milestones) {
+            const mark = milestone.status === 'completed' ? '\u2713' : '\u25CB';
+            const dateStr = milestone.dateText || 'TBD';
+            parts.push(new Paragraph({
+                children: [
+                    monoRun(`${mark} `, { size: S.sizes.meta }),
+                    serifRun(`${milestone.kind}: ${dateStr}`, { size: S.sizes.meta }),
+                ],
+                indent: { left: 216 },
+            }));
+        }
+    }
+
+    // Selection Panel
+    if (options.includeSelectionPanel && hasSelectionPanelContent(project)) {
+        parts.push(new Paragraph({
+            children: [labelRun('Selection Panel')],
+            spacing: { before: 80, after: 40 },
+        }));
+        if (project.selectionPanelBlock.selectedArtist) {
+            parts.push(new Paragraph({
+                children: [
+                    serifRun('Selected: ', { size: S.sizes.meta, color: S.colors.textSecondary }),
+                    serifRun(project.selectionPanelBlock.selectedArtist, { size: S.sizes.meta, bold: true }),
+                ],
+                indent: { left: 216 },
+            }));
+        }
+        if (project.selectionPanelBlock.artworkTitle) {
+            parts.push(new Paragraph({
+                children: [
+                    serifRun('Artwork: ', { size: S.sizes.meta, color: S.colors.textSecondary }),
+                    serifRun(project.selectionPanelBlock.artworkTitle, { size: S.sizes.meta }),
+                ],
+                indent: { left: 216 },
+            }));
+        }
+        if (project.selectionPanelBlock.shortlist.length > 0) {
+            parts.push(new Paragraph({
+                children: [
+                    serifRun('Shortlist: ', { size: S.sizes.meta, color: S.colors.textSecondary }),
+                    serifRun(project.selectionPanelBlock.shortlist.join(', '), { size: S.sizes.meta }),
+                ],
+                indent: { left: 216 },
+            }));
+        }
+    }
+
+    // Status
+    if (options.includeStatusNotes && project.statusBlock.projectStatusText) {
+        parts.push(new Paragraph({
+            children: [labelRun('Status')],
+            spacing: { before: 80, after: 40 },
+        }));
+        parts.push(new Paragraph({
+            children: [serifRun(project.statusBlock.projectStatusText, { size: S.sizes.meta })],
+            indent: { left: 216 },
+        }));
+    }
+
+    // Next Steps
+    const stepsToShow = options.includeOnlyOpenNextSteps
+        ? project.nextStepsBullets.filter((s) => !s.completed)
+        : project.nextStepsBullets;
+
+    if (stepsToShow.length > 0) {
+        parts.push(new Paragraph({
+            children: [labelRun('Next Steps')],
+            spacing: { before: 80, after: 40 },
+        }));
+        for (const step of stepsToShow) {
+            const bullet = step.completed ? '\u2713' : '\u2022';
+            const assignee = step.assigneeHint ? ` (${step.assigneeHint})` : '';
+            parts.push(new Paragraph({
+                children: [
+                    monoRun(`${bullet} `, { size: S.sizes.meta }),
+                    serifRun(step.text + assignee, {
+                        size: S.sizes.meta,
+                        color: step.completed ? S.colors.textSecondary : S.colors.text,
+                    }),
+                ],
+                indent: { left: 216 },
+            }));
+        }
+    }
+
+    // Spacer after project
+    parts.push(new Paragraph({ spacing: { after: 160 } }));
+
+    return parts;
+}
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+function hasSelectionPanelContent(project: BfaProjectExportModel): boolean {
+    const sp = project.selectionPanelBlock;
+    return !!(sp.selectedArtist || sp.artworkTitle || sp.shortlist.length > 0 || sp.members.length > 0);
+}
+
+function formatHeaderLine(project: BfaProjectExportModel): string {
+    const initials = project.header.staffInitials.join('/') || 'XX';
+    const budgetParts: string[] = [];
+
+    if (project.header.budgets.artwork?.text) {
+        budgetParts.push(`Art: ${project.header.budgets.artwork.text}`);
+    }
+    if (project.header.budgets.total?.text) {
+        budgetParts.push(`Total: ${project.header.budgets.total.text}`);
+    }
+
+    let line = `(${initials}) ${project.header.clientName}: ${project.header.projectName}`;
+
+    if (project.header.location) {
+        line += `, ${project.header.location}`;
+    }
+
+    if (budgetParts.length > 0) {
+        line += ` (${budgetParts.join(', ')})`;
+    }
+
+    if (project.header.install.dateText) {
+        line += `, Install: ${project.header.install.dateText}`;
+    }
+
+    return line;
+}

--- a/shared/src/formatters/index.ts
+++ b/shared/src/formatters/index.ts
@@ -1,4 +1,5 @@
 export * from './pdf-formatter.js';
+export * from './bfa-docx-formatter.js';
 export * from './gantt-formatter.js';
 export * from './invoice-pdf-formatter.js';
 export * from './invoice-docx-formatter.js';


### PR DESCRIPTION
## **User description**
- Add case 'pdf' and case 'docx' to executeExport() switch
- New bfa-docx-formatter.ts using Parchment design tokens (Source Serif 4)
- PDF export renders via AutoHelper /render/pdf, stores output via output-store
- DOCX export generates via docx package, stores output via output-store
- Both set downloadUrl pointing to GET /sessions/:id/output
- Add DOCX to frontend EXPORT_FORMATS list

Refs #276

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #286**
  * **PR #287** 👈
    * **PR #288**
      * **PR #289**
        * **PR #290**
          * **PR #292**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->

## Summary by Sourcery

Add support for exporting sessions to PDF and DOCX formats and wire them through backend execution and shared formatting utilities.

New Features:
- Enable PDF export in the backend export execution flow using an external rendering service and session output storage.
- Enable DOCX export in the backend export execution flow using a new BFA-specific DOCX formatter and session output storage.
- Expose DOCX as an available export option in the frontend export formats list.

Enhancements:
- Introduce a shared BFA DOCX formatter that generates Word documents using design system tokens and structured project sections.


___

## **CodeAnt-AI Description**
Wire PDF and DOCX export into session execution and UI

### What Changed
- Sessions can now be exported as PDF; backend renders HTML via AutoHelper /render/pdf, stores the PDF, and exposes a download URL for the session output
- Sessions can now be exported as Word .docx; backend generates a DOCX using a new BFA DOCX formatter, stores the file, and exposes a download URL for the session output
- Frontend export options include DOCX and PDF (PDF noted as produced via AutoHelper)
- New BFA DOCX formatter produces structured, styled Word documents (project sections, grouped categories, design tokens) for BFA exports

### Impact
`✅ Export sessions as PDF`
`✅ Export sessions as Word .docx`
`✅ Downloadable session outputs via /api/exports/sessions/:id/output`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
