### PR TITLE
fix: address review feedback across PRs #286-#290

### DIFF
--- a/backend/src/db/migrations/048_export_output_storage.ts
+++ b/backend/src/db/migrations/048_export_output_storage.ts
@@ -42,6 +42,11 @@ export async function down(db: Kysely<unknown>): Promise<void> {
         DROP COLUMN IF EXISTS output_mime_type;
     `.execute(db);
 
+    // Remove sessions with formats that the narrower constraint won't allow
+    await sql`
+        DELETE FROM export_sessions WHERE format IN ('pdf', 'docx');
+    `.execute(db);
+
     // Restore previous constraint (7 formats, no pdf/docx)
     await sql`
         ALTER TABLE export_sessions

--- a/backend/src/modules/exports/projectors/budget.projector.ts
+++ b/backend/src/modules/exports/projectors/budget.projector.ts
@@ -6,6 +6,7 @@
  */
 
 import { db } from '@db/client.js';
+import { extractAmountCents } from '../utils/extract-amount.js';
 
 // ============================================================================
 // EXPORT MODEL
@@ -35,7 +36,7 @@ export async function projectBudgets(projectId: string): Promise<BudgetExportRow
         .where('name', '=', 'Budget')
         .executeTakeFirst();
 
-    if (!budgetDef) return [];
+    if (!budgetDef) throw new Error('Budget record definition not found');
 
     const budgets = await db
         .selectFrom('records')
@@ -61,15 +62,3 @@ export async function projectBudgets(projectId: string): Promise<BudgetExportRow
     });
 }
 
-// ============================================================================
-// HELPERS
-// ============================================================================
-
-function extractAmountCents(data: Record<string, unknown>, key: string): number {
-    const val = data[key];
-    if (typeof val === 'number') return val;
-    if (typeof val === 'object' && val !== null && 'amount' in val) {
-        return (val as { amount: number }).amount;
-    }
-    return 0;
-}

--- a/backend/src/modules/exports/projectors/invoice-list.projector.ts
+++ b/backend/src/modules/exports/projectors/invoice-list.projector.ts
@@ -6,6 +6,7 @@
  */
 
 import { db } from '@db/client.js';
+import { extractAmountCents } from '../utils/extract-amount.js';
 
 // ============================================================================
 // EXPORT MODEL
@@ -53,7 +54,7 @@ export async function projectInvoiceList(projectId: string): Promise<InvoiceList
         const tax = extractAmountCents(data, 'tax_total');
         return {
             invoiceNumber: (data.invoice_number as string) || r.unique_name,
-            client: '',
+            client: (data.client_name as string) || '',
             issueDate: (data.issue_date as string) || '',
             dueDate: (data.due_date as string) || '',
             subtotal,
@@ -65,15 +66,3 @@ export async function projectInvoiceList(projectId: string): Promise<InvoiceList
     });
 }
 
-// ============================================================================
-// HELPERS
-// ============================================================================
-
-function extractAmountCents(data: Record<string, unknown>, key: string): number {
-    const val = data[key];
-    if (typeof val === 'number') return val;
-    if (typeof val === 'object' && val !== null && 'amount' in val) {
-        return (val as { amount: number }).amount;
-    }
-    return 0;
-}

--- a/backend/src/modules/exports/utils/extract-amount.ts
+++ b/backend/src/modules/exports/utils/extract-amount.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared utility for extracting monetary amounts from record data.
+ * Handles both raw number values and structured { amount: number } objects.
+ */
+export function extractAmountCents(data: Record<string, unknown>, key: string): number {
+    const val = data[key];
+    if (typeof val === 'number') return val;
+    if (typeof val === 'object' && val !== null && 'amount' in val) {
+        return (val as { amount: number }).amount;
+    }
+    return 0;
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,6 @@
 // In production, set VITE_API_URL to the backend URL (e.g., https://backend-xxx.onrender.com/api)
 // In development, Vite proxies /api to localhost:3001
-const API_BASE = import.meta.env.VITE_API_URL || '/api';
+export const API_BASE = import.meta.env.VITE_API_URL || '/api';
 
 interface FetchOptions extends RequestInit {
   skipAuth?: boolean;

--- a/frontend/src/api/hooks/exports.ts
+++ b/frontend/src/api/hooks/exports.ts
@@ -14,7 +14,7 @@ import type {
     ExportResult,
     BfaProjectExportModel,
 } from '../../workflows/export/types';
-import { api } from '../client';
+import { api, API_BASE } from '../client';
 
 // Re-export types for consumers
 export type { ExportFormat, ExportSessionStatus, ExportSession, ExportResult };
@@ -195,7 +195,7 @@ export function useDeleteExportSession() {
 export function useDownloadExportOutput() {
     return useMutation({
         mutationFn: async (sessionId: string) => {
-            const response = await fetch(`/api/exports/sessions/${sessionId}/output?disposition=attachment`);
+            const response = await fetch(`${API_BASE}/exports/sessions/${sessionId}/output?disposition=attachment`);
 
             if (!response.ok) {
                 throw new Error(`Download failed: ${response.statusText}`);

--- a/frontend/src/workflows/export/components/ExportStepIndicator.tsx
+++ b/frontend/src/workflows/export/components/ExportStepIndicator.tsx
@@ -1,7 +1,7 @@
 /**
  * ExportStepIndicator
  *
- * Minimal step bar: Configure → Execute → Output.
+ * Minimal step bar: Configure → Output.
  * Derives position from the current step in the store.
  */
 

--- a/frontend/src/workflows/export/components/PdfPreview.tsx
+++ b/frontend/src/workflows/export/components/PdfPreview.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Document, Page, pdfjs } from 'react-pdf';
 import { Loader2 } from 'lucide-react';
 
@@ -18,6 +18,12 @@ export function PdfPreview({ url }: PdfPreviewProps) {
     const [numPages, setNumPages] = useState<number | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        setNumPages(null);
+        setError(null);
+        setLoading(true);
+    }, [url]);
 
     return (
         <div

--- a/frontend/src/workflows/export/views/ExportWorkbenchContent.tsx
+++ b/frontend/src/workflows/export/views/ExportWorkbenchContent.tsx
@@ -10,11 +10,13 @@
 
 import { clsx } from 'clsx';
 import { Eye, FileText, Download, Loader2 } from 'lucide-react';
+import { useState } from 'react';
 
 import { ExportOutputPanel } from '../components/ExportOutputPanel';
 import { ExportPreview } from '../components/ExportPreview';
 import { ExportStepIndicator } from '../components/ExportStepIndicator';
 import { EXPORT_FORMATS } from '../types';
+import type { ExportResult } from '../types';
 import {
     useCreateExportSession,
     useGenerateExportProjection,
@@ -43,6 +45,8 @@ export function ExportWorkbenchContent() {
     const generateProjection = useGenerateExportProjection();
     const executeExport = useExecuteExport();
 
+    const [exportResult, setExportResult] = useState<ExportResult>();
+
     const isExporting = createSession.isPending || generateProjection.isPending || executeExport.isPending;
     const selectedCount = selectedProjectIds.size;
 
@@ -59,6 +63,7 @@ export function ExportWorkbenchContent() {
             await generateProjection.mutateAsync(session.id);
 
             const result = await executeExport.mutateAsync(session.id);
+            setExportResult(result);
 
             // Transition to output step
             setActiveSession(session.id);
@@ -80,7 +85,7 @@ export function ExportWorkbenchContent() {
 
     // ── Output step ──────────────────────────────────────────────────
     if (step === 'output' && activeSessionId) {
-        return <ExportOutputPanel sessionId={activeSessionId} onBack={handleBack} />;
+        return <ExportOutputPanel sessionId={activeSessionId} exportResult={exportResult} onBack={handleBack} />;
     }
 
     // ── Configure step ───────────────────────────────────────────────

--- a/shared/src/formatters/bfa-docx-formatter.ts
+++ b/shared/src/formatters/bfa-docx-formatter.ts
@@ -35,7 +35,7 @@ const S = compileDocxStyles(PARCHMENT_TOKENS);
 function serifRun(text: string, options?: { bold?: boolean; size?: number; color?: string }): TextRun {
     return new TextRun({
         text,
-        font: { name: S.fonts.primary, hint: undefined },
+        font: S.fonts.primary,
         size: options?.size ?? S.sizes.body,
         bold: options?.bold,
         color: options?.color ?? S.colors.text,
@@ -45,7 +45,7 @@ function serifRun(text: string, options?: { bold?: boolean; size?: number; color
 function monoRun(text: string, options?: { size?: number; color?: string }): TextRun {
     return new TextRun({
         text,
-        font: { name: S.fonts.mono, hint: undefined },
+        font: S.fonts.mono,
         size: options?.size ?? S.sizes.mono,
         color: options?.color ?? S.colors.textSecondary,
     });
@@ -54,7 +54,7 @@ function monoRun(text: string, options?: { size?: number; color?: string }): Tex
 function labelRun(text: string): TextRun {
     return new TextRun({
         text,
-        font: { name: S.fonts.primary, hint: undefined },
+        font: S.fonts.primary,
         size: S.sizes.meta,
         color: S.colors.accentSecondary,
         allCaps: true,
@@ -228,6 +228,24 @@ function formatProject(project: BfaProjectExportModel, options: ExportOptions): 
                 indent: { left: 216 },
             }));
         }
+        if (project.selectionPanelBlock.members.length > 0) {
+            parts.push(new Paragraph({
+                children: [
+                    serifRun('Members: ', { size: S.sizes.meta, color: S.colors.textSecondary }),
+                    serifRun(project.selectionPanelBlock.members.join(', '), { size: S.sizes.meta }),
+                ],
+                indent: { left: 216 },
+            }));
+        }
+        if (project.selectionPanelBlock.alternates.length > 0) {
+            parts.push(new Paragraph({
+                children: [
+                    serifRun('Alternates: ', { size: S.sizes.meta, color: S.colors.textSecondary }),
+                    serifRun(project.selectionPanelBlock.alternates.join(', '), { size: S.sizes.meta }),
+                ],
+                indent: { left: 216 },
+            }));
+        }
     }
 
     // Status
@@ -280,7 +298,7 @@ function formatProject(project: BfaProjectExportModel, options: ExportOptions): 
 
 function hasSelectionPanelContent(project: BfaProjectExportModel): boolean {
     const sp = project.selectionPanelBlock;
-    return !!(sp.selectedArtist || sp.artworkTitle || sp.shortlist.length > 0 || sp.members.length > 0);
+    return !!(sp.selectedArtist || sp.artworkTitle || sp.shortlist.length > 0 || sp.members.length > 0 || sp.alternates.length > 0);
 }
 
 function formatHeaderLine(project: BfaProjectExportModel): string {


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #286**
  * **PR #287**
    * **PR #288**
      * **PR #289**
        * **PR #290**
          * **PR #292** 👈

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
**Require correct preset IDs, restrict download access, and make export output handling safer**

### What Changed
- Downloading an export output now denies access when the requesting user is not the export creator; unauthenticated or mismatched users receive a 403.
- Finance export endpoint enforces that invoice-based presets require invoiceId and CSV presets require projectId; requests missing the required ID return a validation error.
- PDF rendering requests to the external renderer time out after 30 seconds to avoid long-hanging export jobs; failed renders return an explicit error.
- Writing exported files is now atomic with cleanup: files are removed if the database update fails, and cleanup only clears DB paths for files actually deleted; the cleanup window checks file age using the session updated time.
- Frontend uses a stable API base for export download and preview URLs, shows a loading state while exports run, gracefully handles clipboard failures, and passes execute results (content or external link) into the output panel so text and cloud exports show actual output or links.
- Docx generation uses direct buffer outputs (reducing unnecessary copies) and the DOCX formatter includes members and alternates in project selection panels; PDF page presets are validated against an allowed list.
- Migration rollback now deletes sessions with pdf/docx formats that the restored constraint would reject.

### Impact
`✅ Clearer access denied for non-creators`
`✅ Fewer stalled export jobs due to timed PDF renders`
`✅ Fewer leftover files after failed output writes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
