### PR TITLE
feat: workspace-aware SelectionInspector with origin tracking

### DIFF
--- a/frontend/src/stores/uiStore.ts
+++ b/frontend/src/stores/uiStore.ts
@@ -137,10 +137,10 @@ interface UIState {
   readonly inspectedRecordId: string | null;
   readonly inspectorMode: InspectorTabId;
   setInspectorMode: (mode: InspectorTabId) => void;
-  inspectRecord: (recordId: string) => void;
-  inspectNode: (nodeId: string) => void;
-  inspectAction: (actionId: string) => void;
-  inspectEmail: (emailId: string) => void;
+  inspectRecord: (recordId: string, origin?: string) => void;
+  inspectNode: (nodeId: string, origin?: string) => void;
+  inspectAction: (actionId: string, origin?: string) => void;
+  inspectEmail: (emailId: string, origin?: string) => void;
   clearSelection: () => void;
   clearInspection: () => void;
 
@@ -149,7 +149,7 @@ interface UIState {
   importPlan: ImportPlan | null;
   setImportSession: (session: ImportSession | null) => void;
   setImportPlan: (plan: ImportPlan | null) => void;
-  selectImportItem: (itemId: string | null) => void;
+  selectImportItem: (itemId: string | null, origin?: string) => void;
 
   // Command palette state
   commandPaletteOpen: boolean;
@@ -260,10 +260,10 @@ export const useUIStore = create<UIState>()(
         return get().inspectorTabMode;
       },
       setInspectorMode: (mode) => set({ inspectorTabMode: mode }),
-      inspectRecord: (recordId) => set({ selection: { type: 'record', id: recordId }, inspectorCollapsed: false }),
-      inspectNode: (nodeId) => set({ selection: { type: 'node', id: nodeId }, inspectorCollapsed: false }),
-      inspectAction: (actionId) => set({ selection: { type: 'action', id: actionId }, inspectorCollapsed: false }),
-      inspectEmail: (emailId) => set({ selection: { type: 'email', id: emailId }, inspectorCollapsed: false }),
+      inspectRecord: (recordId, origin) => set({ selection: { type: 'record', id: recordId, origin }, inspectorCollapsed: false }),
+      inspectNode: (nodeId, origin) => set({ selection: { type: 'node', id: nodeId, origin }, inspectorCollapsed: false }),
+      inspectAction: (actionId, origin) => set({ selection: { type: 'action', id: actionId, origin }, inspectorCollapsed: false }),
+      inspectEmail: (emailId, origin) => set({ selection: { type: 'email', id: emailId, origin }, inspectorCollapsed: false }),
       clearSelection: () => set({ selection: null }),
       clearInspection: () => set({ selection: null }),
 
@@ -272,8 +272,8 @@ export const useUIStore = create<UIState>()(
       importPlan: null,
       setImportSession: (session) => set({ importSession: session }),
       setImportPlan: (plan) => set({ importPlan: plan }),
-      selectImportItem: (itemId) => set({
-        selection: itemId ? { type: 'import_item', id: itemId } : null,
+      selectImportItem: (itemId, origin) => set({
+        selection: itemId ? { type: 'import_item', id: itemId, origin } : null,
         inspectorCollapsed: false,
         inspectorTabMode: itemId ? 'import_details' : get().inspectorTabMode,
       }),

--- a/frontend/src/types/ui.ts
+++ b/frontend/src/types/ui.ts
@@ -1,11 +1,11 @@
 export type Selection =
-  | { type: 'node'; id: string }
-  | { type: 'record'; id: string }
-  | { type: 'definition'; id: string }
-  | { type: 'project'; id: string }
-  | { type: 'action'; id: string }
-  | { type: 'email'; id: string }
-  | { type: 'import_item'; id: string }
+  | { type: 'node'; id: string; origin?: string }
+  | { type: 'record'; id: string; origin?: string }
+  | { type: 'definition'; id: string; origin?: string }
+  | { type: 'project'; id: string; origin?: string }
+  | { type: 'action'; id: string; origin?: string }
+  | { type: 'email'; id: string; origin?: string }
+  | { type: 'import_item'; id: string; origin?: string }
   | null;
 
 /** Valid inspector tab IDs */

--- a/frontend/src/ui/composites/ProjectView.tsx
+++ b/frontend/src/ui/composites/ProjectView.tsx
@@ -170,11 +170,11 @@ export function ProjectView({ projectId, className }: ProjectViewProps) {
     // Handlers
     const handleSelectSubprocess = (subprocessId: string) => {
         setInspectorMode('record');
-        inspectNode(subprocessId);
+        inspectNode(subprocessId, 'center-workspace');
     };
 
     const handleSelectRecord = (recordId: string) => {
-        inspectRecord(recordId);
+        inspectRecord(recordId, 'center-workspace');
         setInspectorMode('record');
     };
 
@@ -406,10 +406,10 @@ export function ProjectView({ projectId, className }: ProjectViewProps) {
                                 const node = storeNodes[event.actionId];
                                 if (node) {
                                     setInspectorMode('record');
-                                    inspectNode(event.actionId);
+                                    inspectNode(event.actionId, 'center-workspace');
                                 } else {
                                     // For actions without hierarchy nodes, use action inspector
-                                    inspectAction(event.actionId);
+                                    inspectAction(event.actionId, 'center-workspace');
                                 }
                             }}
                         />

--- a/frontend/src/ui/inspector/MappingsPanel.tsx
+++ b/frontend/src/ui/inspector/MappingsPanel.tsx
@@ -281,9 +281,9 @@ function ActionMappingsPanel({
 
     const handleNavigate = useCallback((entry: MappingEntry) => {
         if (entry.type === 'record') {
-            inspectRecord(entry.id);
+            inspectRecord(entry.id, 'selection-inspector');
         } else if (entry.type === 'action') {
-            inspectAction(entry.id);
+            inspectAction(entry.id, 'selection-inspector');
         }
     }, [inspectRecord, inspectAction]);
 
@@ -530,7 +530,7 @@ function RecordMappingsPanel({
                                     status: 'synced',
                                     mode: ref.mode,
                                 }}
-                                onNavigate={() => inspectAction(ref.actionId)}
+                                onNavigate={() => inspectAction(ref.actionId, 'selection-inspector')}
                             />
                         ))}
                     </div>

--- a/frontend/src/ui/layout/ProjectWorkflowView.tsx
+++ b/frontend/src/ui/layout/ProjectWorkflowView.tsx
@@ -299,7 +299,7 @@ export function ProjectWorkflowView() {
         (subprocessId: string) => {
             setLocalSubprocessId(subprocessId);
             setInspectorMode('record');
-            inspectNode(subprocessId);
+            inspectNode(subprocessId, 'center-workspace');
         },
         [setInspectorMode, inspectNode]
     );
@@ -398,7 +398,7 @@ export function ProjectWorkflowView() {
             });
 
             if (matchingTask) {
-                inspectNode(matchingTask.id);
+                inspectNode(matchingTask.id, 'center-workspace');
             }
         },
         [tasks, setInspectorMode, inspectNode]
@@ -719,7 +719,7 @@ export function ProjectWorkflowView() {
                                             onRowSelect={(nodeId) => {
                                                 setFocusedTableId('tasks');
                                                 setInspectorMode('record');
-                                                inspectNode(nodeId);
+                                                inspectNode(nodeId, 'center-workspace');
                                             }}
                                             onCellChange={handleCellChange}
                                             onAddNode={undefined}
@@ -779,7 +779,7 @@ export function ProjectWorkflowView() {
                                                     selectedRecordId={selectedRecordId}
                                                     onRowSelect={(id) => {
                                                         setFocusedTableId(definition.id);
-                                                        useUIStore.getState().inspectRecord(id);
+                                                        useUIStore.getState().inspectRecord(id, 'center-workspace');
                                                         setInspectorMode('record');
                                                     }}
                                                     onCellChange={handleRecordCellChange}

--- a/frontend/src/ui/records/RecordGrid.tsx
+++ b/frontend/src/ui/records/RecordGrid.tsx
@@ -144,7 +144,7 @@ export function RecordGrid({ definitionId }: RecordGridProps) {
   };
 
   const handleRowClick = (record: DataRecord) => {
-    inspectRecord(record.id);
+    inspectRecord(record.id, 'center-workspace');
   };
 
   const handleCreateRecord = () => {

--- a/frontend/src/ui/tables/ActionInstancesView.tsx
+++ b/frontend/src/ui/tables/ActionInstancesView.tsx
@@ -58,7 +58,7 @@ export function ActionInstancesView({
 
     // Handlers
     const handleSelectAction = useCallback((actionId: string) => {
-        inspectAction(actionId);
+        inspectAction(actionId, 'center-workspace');
     }, [inspectAction]);
 
     const handleCreateAction = useCallback(() => {

--- a/frontend/src/ui/tables/UniversalTableView.tsx
+++ b/frontend/src/ui/tables/UniversalTableView.tsx
@@ -361,7 +361,7 @@ export function UniversalTableView({
     }, []);
 
     const handleSelectRecord = useCallback((recordId: string) => {
-        inspectRecord(recordId);
+        inspectRecord(recordId, 'center-workspace');
     }, [inspectRecord]);
 
     const handleCreateRecord = useCallback(() => {

--- a/frontend/src/ui/workspace/content/MailContent.tsx
+++ b/frontend/src/ui/workspace/content/MailContent.tsx
@@ -346,7 +346,7 @@ export function MailContent() {
 
     // Stabilized handlers for memoized EmailRow (defined after hooks)
     const handleRowClick = useCallback((emailId: string) => {
-        inspectEmail(emailId);
+        inspectEmail(emailId, 'center-workspace');
     }, [inspectEmail]);
 
     const handleRefetch = useCallback(() => {

--- a/frontend/src/workspace/workspacePresets.ts
+++ b/frontend/src/workspace/workspacePresets.ts
@@ -49,7 +49,7 @@ export const BUILT_IN_WORKSPACES: WorkspacePreset[] = [
         isBuiltIn: true,
         panels: [
             { panelId: 'center-workspace', contentType: 'projects', viewMode: 'workflow', position: 'center' },
-            { panelId: 'selection-inspector', position: 'right' },
+            { panelId: 'selection-inspector', position: 'right', bound: true },
         ],
     },
     {
@@ -61,7 +61,7 @@ export const BUILT_IN_WORKSPACES: WorkspacePreset[] = [
         isBuiltIn: true,
         panels: [
             { panelId: 'center-workspace', contentType: 'projects', viewMode: 'workflow', position: 'center' },
-            { panelId: 'selection-inspector', position: 'right' },
+            { panelId: 'selection-inspector', position: 'right', bound: true },
             { panelId: 'composer-workbench', position: 'bottom' },
         ],
     },
@@ -74,7 +74,7 @@ export const BUILT_IN_WORKSPACES: WorkspacePreset[] = [
         isBuiltIn: true,
         panels: [
             { panelId: 'center-workspace', contentType: 'projects', viewMode: 'log', position: 'center' },
-            { panelId: 'selection-inspector', position: 'right' },
+            { panelId: 'selection-inspector', position: 'right', bound: true },
         ],
     },
     {


### PR DESCRIPTION
## **User description**
## Summary by Sourcery

Make the SelectionInspector workspace-aware by tracking the origin of selections and binding it to workspace panels.

New Features:
- Track selection origin across the UI store and selection types to distinguish where selections come from.
- Bind the selection inspector panel to specific workspaces so it only reacts to workspace-scoped selections and displays workspace labels in its UI.

Enhancements:
- Update project, table, mail, and mappings views to pass workspace or inspector panel origins when triggering inspections, aligning selections with the active workspace context.


___

## **CodeAnt-AI Description**
Make SelectionInspector workspace-bound and track where selections come from

### What Changed
- The inspector can be bound to a workspace so it only shows selections originating from panels in the same workspace; selections from other panels are ignored when bound.
- Selection objects now carry an optional origin tag and legacy inspect actions accept an origin; many views now tag selections (e.g., 'center-workspace' or 'selection-inspector') so inspections are scoped correctly.
- When the inspector is bound it displays the active workspace label in the header and shows "No selection in <Workspace>" when there are no workspace-scoped selections.
- Built-in workspace presets mark the selection inspector as bound to ensure workspace-scoped behavior.

### Impact
`✅ Fewer cross-workspace selection leaks`
`✅ Clearer workspace context in the inspector`
`✅ More predictable inspection when switching panels`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #298** 👈
  * **PR #299**
    * **PR #300**
      * **PR #301**
        * **PR #302**
          * **PR #303**
            * **PR #304**
              * **PR #305**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->