### PR TITLE
refactor: migrate custom dropdown menus to shared atoms

### DIFF
--- a/frontend/src/pages/MailPage.tsx
+++ b/frontend/src/pages/MailPage.tsx
@@ -9,21 +9,15 @@ import {
   Circle,
   Sparkles,
   Paperclip,
-  MoreHorizontal,
-  AlertTriangle,
-  Info,
-  Archive,
 } from 'lucide-react';
 
 import {
   useInbox,
   useEnrichedInbox,
   useMailStatus,
-  useArchiveEmail,
-  useMarkActionRequired,
-  useMarkInformational
 } from '../api/hooks/mail';
 import type { ProcessedEmail, Priority, TriageStatus as TriageStatusType } from '../api/types/mail';
+import { EmailActionsMenu } from '../ui/mail/EmailActionsMenu';
 
 const ITEMS_PER_PAGE = 25;
 
@@ -58,77 +52,6 @@ function TriageStatusIndicator({ status, confidence }: { status: TriageStatusTyp
       <Circle size={8} className={`${color} fill-current`} />
       {showConfidence && (
         <span className="text-[10px] text-slate-400">{Math.round(confidence * 100)}%</span>
-      )}
-    </div>
-  );
-}
-
-function EmailActions({ email, onAction }: { email: ProcessedEmail; onAction?: () => void }) {
-  const [showMenu, setShowMenu] = useState(false);
-  const archiveMutation = useArchiveEmail();
-  const actionRequiredMutation = useMarkActionRequired();
-  const informationalMutation = useMarkInformational();
-
-  const handleArchive = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    archiveMutation.mutate(email.id, { onSuccess: onAction });
-    setShowMenu(false);
-  };
-
-  const handleMarkActionRequired = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    actionRequiredMutation.mutate(email.id, { onSuccess: onAction });
-    setShowMenu(false);
-  };
-
-  const handleMarkInformational = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    informationalMutation.mutate(email.id, { onSuccess: onAction });
-    setShowMenu(false);
-  };
-
-  const isPending = archiveMutation.isPending || actionRequiredMutation.isPending || informationalMutation.isPending;
-
-  return (
-    <div className="relative">
-      <button
-        onClick={(e) => {
-          e.stopPropagation();
-          setShowMenu(!showMenu);
-        }}
-        disabled={isPending}
-        className="p-1.5 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded transition-colors disabled:opacity-50"
-      >
-        {isPending ? <Loader2 size={14} className="animate-spin" /> : <MoreHorizontal size={14} />}
-      </button>
-      {showMenu && (
-        <>
-          <div className="fixed inset-0 z-10" onClick={() => setShowMenu(false)} />
-          <div className="absolute right-0 top-full mt-1 z-20 bg-white border border-slate-200 rounded-lg shadow-lg py-1 min-w-[160px]">
-            <button
-              onClick={handleMarkActionRequired}
-              className="w-full px-3 py-2 text-left text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2"
-            >
-              <AlertTriangle size={14} className="text-red-500" />
-              Action Required
-            </button>
-            <button
-              onClick={handleMarkInformational}
-              className="w-full px-3 py-2 text-left text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2"
-            >
-              <Info size={14} className="text-blue-500" />
-              Informational
-            </button>
-            <hr className="my-1 border-slate-100" />
-            <button
-              onClick={handleArchive}
-              className="w-full px-3 py-2 text-left text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2"
-            >
-              <Archive size={14} className="text-slate-400" />
-              Archive
-            </button>
-          </div>
-        </>
       )}
     </div>
   );
@@ -179,7 +102,7 @@ function EmailRow({ email, onAction }: { email: ProcessedEmail; onAction?: () =>
       </td>
       <td className="px-4 py-3 w-32 text-sm text-slate-500">{formattedDate}</td>
       <td className="px-4 py-3 w-12">
-        <EmailActions email={email} onAction={onAction} />
+        <EmailActionsMenu email={email} onAction={onAction} />
       </td>
     </tr>
   );

--- a/frontend/src/ui/inspector/MappingsPanel.tsx
+++ b/frontend/src/ui/inspector/MappingsPanel.tsx
@@ -26,7 +26,7 @@ import {
 } from 'lucide-react';
 import { useMemo, useState, useRef, useCallback, useEffect } from 'react';
 
-import { Badge } from '@autoart/ui';
+import { Badge, Menu } from '@autoart/ui';
 
 import { LinkSearchCombobox } from './LinkSearchCombobox';
 
@@ -114,30 +114,9 @@ function MappingRow({
     onNavigate?: (entry: MappingEntry) => void;
     onUnlink?: (entry: MappingEntry) => void;
 }) {
-    const [showMenu, setShowMenu] = useState(false);
-    const menuRef = useRef<HTMLDivElement>(null);
-    const menuButtonRef = useRef<HTMLButtonElement>(null);
     const Icon = entityIcons[entry.type] || fallbackIcon;
     const statusInfo = statusConfig[entry.status] || fallbackStatusConfig;
     const StatusIcon = statusInfo.icon;
-
-    // Close menu on Escape and handle focus
-    useEffect(() => {
-        if (!showMenu) return;
-
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') {
-                setShowMenu(false);
-                menuButtonRef.current?.focus();
-            }
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-        // Focus the menu when opened
-        menuRef.current?.querySelector('button')?.focus();
-
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [showMenu]);
 
     return (
         <div
@@ -184,44 +163,25 @@ function MappingRow({
 
             {/* Actions menu */}
             {onUnlink && (
-                <div className="relative">
-                    <button
-                        ref={menuButtonRef}
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            setShowMenu(prev => !prev);
-                        }}
-                        aria-haspopup="menu"
-                        aria-expanded={showMenu}
-                        className="p-1 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded transition-colors"
-                    >
-                        <MoreHorizontal size={14} />
-                    </button>
-                    {showMenu && (
-                        <>
-                            <div className="fixed inset-0 z-10" onClick={() => setShowMenu(false)} />
-                            <div
-                                ref={menuRef}
-                                role="menu"
-                                aria-label="Mapping actions"
-                                className="absolute right-0 top-full mt-1 z-20 bg-white border border-slate-200 rounded-lg shadow-lg py-1 min-w-[120px]"
-                            >
-                                <button
-                                    role="menuitem"
-                                    onClick={(e) => {
-                                        e.stopPropagation();
-                                        setShowMenu(false);
-                                        onUnlink(entry);
-                                    }}
-                                    className="w-full px-3 py-1.5 text-left text-sm text-red-600 hover:bg-red-50 flex items-center gap-2"
-                                >
-                                    <Unlink size={12} />
-                                    Unlink
-                                </button>
-                            </div>
-                        </>
-                    )}
-                </div>
+                <Menu>
+                    <Menu.Target>
+                        <button
+                            onClick={(e) => e.stopPropagation()}
+                            className="p-1 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded transition-colors"
+                        >
+                            <MoreHorizontal size={14} />
+                        </button>
+                    </Menu.Target>
+                    <Menu.Dropdown align="end">
+                        <Menu.Item
+                            leftSection={<Unlink size={12} />}
+                            className="text-red-600"
+                            onClick={() => onUnlink(entry)}
+                        >
+                            Unlink
+                        </Menu.Item>
+                    </Menu.Dropdown>
+                </Menu>
             )}
 
             {/* Navigate arrow */}

--- a/frontend/src/ui/mail/EmailActionsMenu.tsx
+++ b/frontend/src/ui/mail/EmailActionsMenu.tsx
@@ -1,0 +1,79 @@
+/**
+ * EmailActionsMenu
+ *
+ * Shared dropdown menu for email triage actions.
+ * Consolidates the inline EmailActions that were duplicated across
+ * MailContent, MailPage, and MailPanel.
+ */
+
+import { MoreHorizontal, AlertTriangle, Info, Archive, Loader2 } from 'lucide-react';
+
+import { Menu } from '@autoart/ui';
+
+import {
+    useArchiveEmail,
+    useMarkActionRequired,
+    useMarkInformational,
+} from '../../api/hooks/mail';
+import type { ProcessedEmail } from '../../api/types/mail';
+
+export interface EmailActionsMenuProps {
+    email: ProcessedEmail;
+    onAction?: () => void;
+}
+
+export function EmailActionsMenu({ email, onAction }: EmailActionsMenuProps) {
+    const archiveMutation = useArchiveEmail();
+    const actionRequiredMutation = useMarkActionRequired();
+    const informationalMutation = useMarkInformational();
+
+    const isPending =
+        archiveMutation.isPending ||
+        actionRequiredMutation.isPending ||
+        informationalMutation.isPending;
+
+    return (
+        <Menu>
+            <Menu.Target>
+                <button
+                    onClick={(e) => e.stopPropagation()}
+                    disabled={isPending}
+                    className="p-1.5 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded transition-colors disabled:opacity-50"
+                >
+                    {isPending ? (
+                        <Loader2 size={14} className="animate-spin" />
+                    ) : (
+                        <MoreHorizontal size={14} />
+                    )}
+                </button>
+            </Menu.Target>
+            <Menu.Dropdown align="end">
+                <Menu.Item
+                    leftSection={<AlertTriangle size={14} className="text-red-500" />}
+                    onClick={() => {
+                        actionRequiredMutation.mutate(email.id, { onSuccess: onAction });
+                    }}
+                >
+                    Action Required
+                </Menu.Item>
+                <Menu.Item
+                    leftSection={<Info size={14} className="text-blue-500" />}
+                    onClick={() => {
+                        informationalMutation.mutate(email.id, { onSuccess: onAction });
+                    }}
+                >
+                    Informational
+                </Menu.Item>
+                <Menu.Divider />
+                <Menu.Item
+                    leftSection={<Archive size={14} className="text-slate-400" />}
+                    onClick={() => {
+                        archiveMutation.mutate(email.id, { onSuccess: onAction });
+                    }}
+                >
+                    Archive
+                </Menu.Item>
+            </Menu.Dropdown>
+        </Menu>
+    );
+}

--- a/frontend/src/ui/mail/index.ts
+++ b/frontend/src/ui/mail/index.ts
@@ -30,3 +30,9 @@ export {
     EmailFactCard,
     type EmailFactCardProps,
 } from './EmailFactCard';
+
+// Email actions menu
+export {
+    EmailActionsMenu,
+    type EmailActionsMenuProps,
+} from './EmailActionsMenu';

--- a/frontend/src/ui/molecules/ColumnPicker.tsx
+++ b/frontend/src/ui/molecules/ColumnPicker.tsx
@@ -6,7 +6,8 @@
  */
 
 import { Columns } from 'lucide-react';
-import { useState, useCallback } from 'react';
+
+import { Dropdown, DropdownTrigger, DropdownContent, DropdownCheckboxItem, DropdownLabel } from '@autoart/ui';
 
 // ============================================================================
 // TYPES
@@ -38,61 +39,37 @@ export function ColumnPicker<T extends ColumnPickerField>({
     onToggle,
     title = 'Visible Columns',
 }: ColumnPickerProps<T>) {
-    const [isOpen, setIsOpen] = useState(false);
-
-    const handleToggle = useCallback((fieldName: string) => {
-        onToggle(fieldName);
-    }, [onToggle]);
-
     return (
-        <div className="relative">
-            <button
-                onClick={() => setIsOpen(!isOpen)}
-                className="p-2 rounded hover:bg-slate-100 text-slate-500"
-                title="Toggle columns"
-            >
-                <Columns size={16} />
-            </button>
-
-            {isOpen && (
-                <>
-                    {/* Backdrop */}
-                    <div
-                        className="fixed inset-0 z-10"
-                        onClick={() => setIsOpen(false)}
-                    />
-
-                    {/* Dropdown */}
-                    <div className="absolute top-full right-0 mt-1 w-48 bg-white border border-slate-200 rounded-lg shadow-lg z-20 py-1 max-h-64 overflow-y-auto">
-                        <div className="px-3 py-1.5 text-[10px] font-bold text-slate-400 uppercase">
-                            {title}
-                        </div>
-                        {allFields.map((field) => {
-                            const label = field.label || field.fieldName;
-                            return (
-                                <label
-                                    key={field.fieldName}
-                                    className="flex items-center gap-2 px-3 py-1.5 text-sm hover:bg-slate-50 cursor-pointer"
-                                >
-                                    <input
-                                        type="checkbox"
-                                        checked={visibleKeys.has(field.fieldName)}
-                                        onChange={() => handleToggle(field.fieldName)}
-                                        className="rounded border-slate-300"
-                                    />
-                                    <span className="truncate">{label}</span>
-                                </label>
-                            );
-                        })}
-                        {allFields.length === 0 && (
-                            <div className="px-3 py-2 text-xs text-slate-400">
-                                No columns available
-                            </div>
-                        )}
+        <Dropdown>
+            <DropdownTrigger asChild>
+                <button
+                    className="p-2 rounded hover:bg-slate-100 text-slate-500"
+                    title="Toggle columns"
+                >
+                    <Columns size={16} />
+                </button>
+            </DropdownTrigger>
+            <DropdownContent align="end" className="w-48 max-h-64 overflow-y-auto">
+                <DropdownLabel>{title}</DropdownLabel>
+                {allFields.map((field) => {
+                    const label = field.label || field.fieldName;
+                    return (
+                        <DropdownCheckboxItem
+                            key={field.fieldName}
+                            checked={visibleKeys.has(field.fieldName)}
+                            onCheckedChange={() => onToggle(field.fieldName)}
+                        >
+                            <span className="truncate">{label}</span>
+                        </DropdownCheckboxItem>
+                    );
+                })}
+                {allFields.length === 0 && (
+                    <div className="px-3 py-2 text-xs text-slate-400">
+                        No columns available
                     </div>
-                </>
-            )}
-        </div>
+                )}
+            </DropdownContent>
+        </Dropdown>
     );
 }
 

--- a/frontend/src/ui/panels/MailPanel.tsx
+++ b/frontend/src/ui/panels/MailPanel.tsx
@@ -9,10 +9,6 @@ import {
     Circle,
     Sparkles,
     Paperclip,
-    MoreHorizontal,
-    AlertTriangle,
-    Info,
-    Archive,
 } from 'lucide-react';
 import type { IDockviewPanelProps } from 'dockview';
 
@@ -20,11 +16,9 @@ import {
     useInbox,
     useEnrichedInbox,
     useMailStatus,
-    useArchiveEmail,
-    useMarkActionRequired,
-    useMarkInformational
 } from '../../api/hooks/mail';
 import type { ProcessedEmail, Priority, TriageStatus as TriageStatusType } from '../../api/types/mail';
+import { EmailActionsMenu } from '../mail/EmailActionsMenu';
 
 const ITEMS_PER_PAGE = 25;
 
@@ -59,77 +53,6 @@ function TriageStatusIndicator({ status, confidence }: { status: TriageStatusTyp
             <Circle size={8} className={`${color} fill-current`} />
             {showConfidence && (
                 <span className="text-[10px] text-slate-400">{Math.round(confidence * 100)}%</span>
-            )}
-        </div>
-    );
-}
-
-function EmailActions({ email, onAction }: { email: ProcessedEmail; onAction?: () => void }) {
-    const [showMenu, setShowMenu] = useState(false);
-    const archiveMutation = useArchiveEmail();
-    const actionRequiredMutation = useMarkActionRequired();
-    const informationalMutation = useMarkInformational();
-
-    const handleArchive = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        archiveMutation.mutate(email.id, { onSuccess: onAction });
-        setShowMenu(false);
-    };
-
-    const handleMarkActionRequired = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        actionRequiredMutation.mutate(email.id, { onSuccess: onAction });
-        setShowMenu(false);
-    };
-
-    const handleMarkInformational = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        informationalMutation.mutate(email.id, { onSuccess: onAction });
-        setShowMenu(false);
-    };
-
-    const isPending = archiveMutation.isPending || actionRequiredMutation.isPending || informationalMutation.isPending;
-
-    return (
-        <div className="relative">
-            <button
-                onClick={(e) => {
-                    e.stopPropagation();
-                    setShowMenu(!showMenu);
-                }}
-                disabled={isPending}
-                className="p-1.5 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded transition-colors disabled:opacity-50"
-            >
-                {isPending ? <Loader2 size={14} className="animate-spin" /> : <MoreHorizontal size={14} />}
-            </button>
-            {showMenu && (
-                <>
-                    <div className="fixed inset-0 z-50" onClick={() => setShowMenu(false)} />
-                    <div className="absolute right-0 top-full mt-1 z-50 bg-white border border-slate-200 rounded-lg shadow-lg py-1 min-w-[160px]">
-                        <button
-                            onClick={handleMarkActionRequired}
-                            className="w-full px-3 py-2 text-left text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2"
-                        >
-                            <AlertTriangle size={14} className="text-red-500" />
-                            Action Required
-                        </button>
-                        <button
-                            onClick={handleMarkInformational}
-                            className="w-full px-3 py-2 text-left text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2"
-                        >
-                            <Info size={14} className="text-blue-500" />
-                            Informational
-                        </button>
-                        <hr className="my-1 border-slate-100" />
-                        <button
-                            onClick={handleArchive}
-                            className="w-full px-3 py-2 text-left text-sm text-slate-700 hover:bg-slate-50 flex items-center gap-2"
-                        >
-                            <Archive size={14} className="text-slate-400" />
-                            Archive
-                        </button>
-                    </div>
-                </>
             )}
         </div>
     );
@@ -178,7 +101,7 @@ function EmailRow({ email, onAction }: { email: ProcessedEmail; onAction?: () =>
             </td>
             <td className="px-4 py-3 w-32 text-sm text-slate-500">{formattedDate}</td>
             <td className="px-4 py-3 w-12">
-                <EmailActions email={email} onAction={onAction} />
+                <EmailActionsMenu email={email} onAction={onAction} />
             </td>
         </tr>
     );

--- a/frontend/src/workflows/export/components/FontSelector.tsx
+++ b/frontend/src/workflows/export/components/FontSelector.tsx
@@ -102,7 +102,7 @@ export function FontSelector({
                 aria-haspopup="listbox"
                 aria-expanded={isOpen}
                 aria-labelledby={labelId}
-                className="w-full flex items-center justify-between px-3 py-2 bg-white border border-slate-300 rounded-lg text-sm hover:border-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="w-full flex items-center justify-between px-3 py-2 bg-white border border-slate-300 rounded-lg text-sm font-sans hover:border-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
             >
                 <span className="flex items-center gap-2">
                     <span style={{ fontFamily: selectedFont }}>{selectedFont}</span>
@@ -121,7 +121,7 @@ export function FontSelector({
                         role="listbox"
                         aria-labelledby={labelId}
                         onKeyDown={handleListKeyDown}
-                        className="absolute z-20 mt-1 w-full bg-white border border-slate-300 rounded-lg shadow-lg max-h-60 overflow-auto focus:outline-none"
+                        className="absolute z-20 mt-1 w-full bg-white border border-slate-300 rounded-lg shadow-lg max-h-60 overflow-auto font-sans focus:outline-none"
                     >
                         {availableFonts.map((font, index) => (
                             <button

--- a/frontend/src/workflows/export/components/TemplatePresetSelector.tsx
+++ b/frontend/src/workflows/export/components/TemplatePresetSelector.tsx
@@ -6,8 +6,9 @@
  */
 
 import { CaretDown, FileText, Table, GoogleLogo, Gear } from '@phosphor-icons/react';
-import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import type { TemplatePreset } from '../../../stores';
+
+import { Dropdown, DropdownTrigger, DropdownContent, DropdownItem } from '@autoart/ui';
 
 // ---------------------------------------------------------------------------
 // Preset Configuration
@@ -59,8 +60,8 @@ export function TemplatePresetSelector({ value, onChange, disabled = false }: Te
     const CurrentIcon = currentConfig.icon;
 
     return (
-        <DropdownMenu.Root>
-            <DropdownMenu.Trigger asChild disabled={disabled}>
+        <Dropdown>
+            <DropdownTrigger asChild disabled={disabled}>
                 <button
                     type="button"
                     className={`
@@ -73,43 +74,37 @@ export function TemplatePresetSelector({ value, onChange, disabled = false }: Te
                     <span className="flex-1 text-left text-sm font-medium">{currentConfig.label}</span>
                     <CaretDown size={14} className="text-slate-400" />
                 </button>
-            </DropdownMenu.Trigger>
+            </DropdownTrigger>
 
-            <DropdownMenu.Portal>
-                <DropdownMenu.Content
-                    className="bg-white rounded-lg border border-slate-200 shadow-lg p-1 min-w-[220px] z-50"
-                    sideOffset={4}
-                    align="start"
-                >
-                    {PRESET_ORDER.map((preset) => {
-                        const config = PRESET_CONFIGS[preset];
-                        const Icon = config.icon;
-                        const isSelected = preset === value;
+            <DropdownContent className="min-w-[220px]" sideOffset={4}>
+                {PRESET_ORDER.map((preset) => {
+                    const config = PRESET_CONFIGS[preset];
+                    const Icon = config.icon;
+                    const isSelected = preset === value;
 
-                        return (
-                            <DropdownMenu.Item
-                                key={preset}
-                                className={`
-                  flex items-start gap-3 px-3 py-2 rounded-md cursor-pointer outline-none
-                  ${isSelected ? 'bg-emerald-50' : 'hover:bg-slate-50'}
+                    return (
+                        <DropdownItem
+                            key={preset}
+                            className={`
+                  flex items-start gap-3 px-3 py-2 rounded-md cursor-pointer
+                  ${isSelected ? 'bg-emerald-50' : ''}
                 `}
-                                onSelect={() => onChange(preset)}
-                            >
-                                <Icon size={18} className={isSelected ? 'text-emerald-600' : 'text-slate-500'} />
-                                <div className="flex-1">
-                                    <div className={`text-sm font-medium ${isSelected ? 'text-emerald-700' : 'text-slate-900'}`}>
-                                        {config.label}
-                                    </div>
-                                    <div className="text-xs text-slate-500">{config.description}</div>
+                            onSelect={() => onChange(preset)}
+                        >
+                            <Icon size={18} className={isSelected ? 'text-emerald-600' : 'text-slate-500'} />
+                            <div className="flex-1">
+                                <div className={`text-sm font-medium ${isSelected ? 'text-emerald-700' : 'text-slate-900'}`}>
+                                    {config.label}
                                 </div>
-                                {isSelected && (
-                                    <div className="text-emerald-600 text-xs font-medium self-center">✓</div>
-                                )}
-                            </DropdownMenu.Item>
-                        );
-                    })}
-                </DropdownMenu.Content>
-            </DropdownMenu.Portal>
-        </DropdownMenu.Root>
+                                <div className="text-xs text-slate-500">{config.description}</div>
+                            </div>
+                            {isSelected && (
+                                <div className="text-emerald-600 text-xs font-medium self-center">✓</div>
+                            )}
+                        </DropdownItem>
+                    );
+                })}
+            </DropdownContent>
+        </Dropdown>
     );
 }

--- a/packages/ui/src/atoms/Dropdown.tsx
+++ b/packages/ui/src/atoms/Dropdown.tsx
@@ -1,6 +1,7 @@
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { clsx } from 'clsx';
+import { Check } from 'lucide-react';
 import { ReactNode } from 'react';
 
 export const Dropdown = DropdownMenu.Root;
@@ -66,4 +67,34 @@ export function DropdownLabel({ children, className }: { children: ReactNode, cl
 
 export function DropdownSeparator({ className }: { className?: string }) {
     return <DropdownMenu.Separator className={clsx("-mx-1 my-1 h-px bg-slate-100", className)} />;
+}
+
+interface DropdownCheckboxItemProps {
+    children: ReactNode;
+    checked?: boolean;
+    onCheckedChange?: (checked: boolean) => void;
+    className?: string;
+    disabled?: boolean;
+}
+
+export function DropdownCheckboxItem({ children, checked, onCheckedChange, className, disabled }: DropdownCheckboxItemProps) {
+    return (
+        <DropdownMenu.CheckboxItem
+            checked={checked}
+            onCheckedChange={onCheckedChange}
+            onSelect={(e) => e.preventDefault()}
+            disabled={disabled}
+            className={clsx(
+                "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm font-sans outline-none transition-colors focus:bg-slate-100 focus:text-slate-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+                className
+            )}
+        >
+            <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+                <DropdownMenu.ItemIndicator>
+                    <Check size={14} />
+                </DropdownMenu.ItemIndicator>
+            </span>
+            {children}
+        </DropdownMenu.CheckboxItem>
+    );
 }


### PR DESCRIPTION



<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #298**
  * **PR #299**
    * **PR #300**
      * **PR #301** 👈
        * **PR #302**
          * **PR #303**
            * **PR #304**
              * **PR #305**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->

## Summary by Sourcery

Refactor email and workflow dropdown menus to use shared UI atoms and consolidate email action logic into a reusable component.

Enhancements:
- Replace inline email action dropdowns in mail views with a shared EmailActionsMenu component.
- Update column picker, template preset selector, and mapping row menus to use shared Dropdown/Menu atoms for consistent behavior and styling.
- Extend the shared Dropdown atom with a checkbox item helper for reusable checkbox-style menu entries.
- Tweak font selector styles to ensure consistent typography in the custom font dropdown.