### PR TITLE
feat: add workspace subview support with nested submenus

### DIFF
--- a/frontend/src/types/workspace.ts
+++ b/frontend/src/types/workspace.ts
@@ -35,6 +35,17 @@ export interface WorkspacePanelConfig {
 }
 
 /**
+ * A named sub-configuration within a workspace.
+ * Single-subview workspaces render as flat menu items;
+ * multi-subview workspaces render as nested submenus.
+ */
+export interface WorkspaceSubview {
+    id: string;
+    label: string;
+    panels: WorkspacePanelConfig[];
+}
+
+/**
  * Workspace Preset
  *
  * A saved configuration that opens specific panels and primes their views.
@@ -54,8 +65,10 @@ export interface WorkspacePreset {
     scope: WorkspaceScope;
     /** Whether this is a built-in workspace (vs user-created) */
     isBuiltIn: boolean;
-    /** Panels to open and configure */
+    /** @deprecated Use subviews instead. Kept for backward compat with custom workspaces. */
     panels: WorkspacePanelConfig[];
+    /** Named sub-configurations. Built-in workspaces should use this. */
+    subviews?: WorkspaceSubview[];
 }
 
 /**

--- a/frontend/src/ui/layout/WorkspaceDropdown.tsx
+++ b/frontend/src/ui/layout/WorkspaceDropdown.tsx
@@ -11,7 +11,7 @@ import { useState } from 'react';
 
 import { Button } from '@autoart/ui';
 import { Menu } from '@autoart/ui';
-import { useWorkspaceStore, useActiveWorkspaceId, useCustomWorkspaces } from '../../stores/workspaceStore';
+import { useWorkspaceStore, useActiveWorkspaceId, useActiveSubviewId, useCustomWorkspaces } from '../../stores/workspaceStore';
 import { BUILT_IN_WORKSPACES } from '../../workspace/workspacePresets';
 import type { WorkspacePreset } from '../../types/workspace';
 import { AddWorkspaceDialog } from './AddWorkspaceDialog';
@@ -56,49 +56,82 @@ function getActiveColorClass(color: string): string {
     return WORKSPACE_COLOR_CONFIG[color]?.active ?? WORKSPACE_COLOR_CONFIG[DEFAULT_COLOR].active;
 }
 
-interface WorkspaceMenuItemProps {
+interface WorkspaceMenuEntryProps {
     workspace: WorkspacePreset;
     isActive: boolean;
-    onSelect: () => void;
+    activeSubviewId: string | null;
+    onSelect: (workspaceId: string, subviewId?: string) => void;
     onDelete?: () => void;
 }
 
-function WorkspaceMenuItem({ workspace, isActive, onSelect, onDelete }: WorkspaceMenuItemProps) {
+function WorkspaceMenuEntry({ workspace, isActive, activeSubviewId, onSelect, onDelete }: WorkspaceMenuEntryProps) {
     const Icon = workspace.icon ?? Folder;
     const colorClasses = getIconColorClass(workspace.color);
+    const hasMultipleSubviews = workspace.subviews && workspace.subviews.length > 1;
 
+    const iconElement = (
+        <span className={`p-1 rounded ${colorClasses}`}>
+            <Icon size={14} />
+        </span>
+    );
+
+    const deleteElement = onDelete ? (
+        <span
+            role="button"
+            tabIndex={0}
+            onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onDelete();
+            }}
+            onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onDelete();
+                }
+            }}
+            className="p-1 hover:bg-red-100 rounded text-slate-400 hover:text-red-600 transition-colors cursor-pointer"
+            title="Delete workspace"
+        >
+            <Trash2 size={12} />
+        </span>
+    ) : undefined;
+
+    // Multi-subview: render as nested submenu
+    if (hasMultipleSubviews) {
+        return (
+            <Menu.Sub>
+                <Menu.SubTrigger
+                    leftSection={iconElement}
+                    className={isActive ? getActiveColorClass(workspace.color) : ''}
+                >
+                    {workspace.label}
+                </Menu.SubTrigger>
+                <Menu.SubContent>
+                    {workspace.subviews!.map((subview) => {
+                        const isSubviewActive = isActive && activeSubviewId === subview.id;
+                        return (
+                            <Menu.Item
+                                key={subview.id}
+                                onClick={() => onSelect(workspace.id, subview.id)}
+                                className={isSubviewActive ? getActiveColorClass(workspace.color) : ''}
+                            >
+                                {subview.label}
+                            </Menu.Item>
+                        );
+                    })}
+                </Menu.SubContent>
+            </Menu.Sub>
+        );
+    }
+
+    // Single subview or no subviews: render as flat item
     return (
         <Menu.Item
-            onClick={onSelect}
-            leftSection={
-                <span className={`p-1 rounded ${colorClasses}`}>
-                    <Icon size={14} />
-                </span>
-            }
-            rightSection={
-                onDelete ? (
-                    <span
-                        role="button"
-                        tabIndex={0}
-                        onClick={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            onDelete();
-                        }}
-                        onKeyDown={(e) => {
-                            if (e.key === 'Enter' || e.key === ' ') {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                onDelete();
-                            }
-                        }}
-                        className="p-1 hover:bg-red-100 rounded text-slate-400 hover:text-red-600 transition-colors cursor-pointer"
-                        title="Delete workspace"
-                    >
-                        <Trash2 size={12} />
-                    </span>
-                ) : undefined
-            }
+            onClick={() => onSelect(workspace.id)}
+            leftSection={iconElement}
+            rightSection={deleteElement}
             className={isActive ? getActiveColorClass(workspace.color) : ''}
         >
             {workspace.label}
@@ -109,6 +142,7 @@ function WorkspaceMenuItem({ workspace, isActive, onSelect, onDelete }: Workspac
 export function WorkspaceDropdown() {
     const [dialogOpen, setDialogOpen] = useState(false);
     const activeWorkspaceId = useActiveWorkspaceId();
+    const activeSubviewId = useActiveSubviewId();
     const customWorkspaces = useCustomWorkspaces();
 
     // Combine built-in + custom workspaces for iteration
@@ -116,8 +150,8 @@ export function WorkspaceDropdown() {
     const activeWorkspace = allWorkspaces.find(w => w.id === activeWorkspaceId);
     const buttonColor = getButtonColor(activeWorkspace?.color ?? DEFAULT_COLOR);
 
-    const handleSelectWorkspace = (workspaceId: string) => {
-        useWorkspaceStore.getState().applyWorkspace(workspaceId);
+    const handleSelectWorkspace = (workspaceId: string, subviewId?: string) => {
+        useWorkspaceStore.getState().applyWorkspace(workspaceId, subviewId);
     };
 
     const handleAddWorkspace = () => {
@@ -147,11 +181,12 @@ export function WorkspaceDropdown() {
                     {/* Built-in workspaces */}
                     <Menu.Label>Workspaces</Menu.Label>
                     {BUILT_IN_WORKSPACES.map((workspace) => (
-                        <WorkspaceMenuItem
+                        <WorkspaceMenuEntry
                             key={workspace.id}
                             workspace={workspace}
                             isActive={activeWorkspaceId === workspace.id}
-                            onSelect={() => handleSelectWorkspace(workspace.id)}
+                            activeSubviewId={activeSubviewId}
+                            onSelect={handleSelectWorkspace}
                         />
                     ))}
 
@@ -161,11 +196,12 @@ export function WorkspaceDropdown() {
                             <Menu.Divider />
                             <Menu.Label>Custom</Menu.Label>
                             {customWorkspaces.map((workspace) => (
-                                <WorkspaceMenuItem
+                                <WorkspaceMenuEntry
                                     key={workspace.id}
                                     workspace={workspace}
                                     isActive={activeWorkspaceId === workspace.id}
-                                    onSelect={() => handleSelectWorkspace(workspace.id)}
+                                    activeSubviewId={activeSubviewId}
+                                    onSelect={handleSelectWorkspace}
                                     onDelete={() => handleDeleteWorkspace(workspace.id)}
                                 />
                             ))}

--- a/frontend/src/workspace/workspacePresets.ts
+++ b/frontend/src/workspace/workspacePresets.ts
@@ -39,6 +39,15 @@ export const BUILT_IN_WORKSPACES: WorkspacePreset[] = [
         panels: [
             { panelId: 'center-workspace', contentType: 'intake', position: 'center' },
         ],
+        subviews: [
+            {
+                id: 'default',
+                label: 'Intake',
+                panels: [
+                    { panelId: 'center-workspace', contentType: 'intake', position: 'center' },
+                ],
+            },
+        ],
     },
     {
         id: 'plan',
@@ -50,6 +59,32 @@ export const BUILT_IN_WORKSPACES: WorkspacePreset[] = [
         panels: [
             { panelId: 'center-workspace', contentType: 'projects', viewMode: 'workflow', position: 'center' },
             { panelId: 'selection-inspector', position: 'right', bound: true },
+        ],
+        subviews: [
+            {
+                id: 'workflow',
+                label: 'Workflow',
+                panels: [
+                    { panelId: 'center-workspace', contentType: 'projects', viewMode: 'workflow', position: 'center' },
+                    { panelId: 'selection-inspector', position: 'right', bound: true },
+                ],
+            },
+            {
+                id: 'columns',
+                label: 'Columns',
+                panels: [
+                    { panelId: 'center-workspace', contentType: 'projects', viewMode: 'columns', position: 'center' },
+                    { panelId: 'selection-inspector', position: 'right', bound: true },
+                ],
+            },
+            {
+                id: 'cards',
+                label: 'Cards',
+                panels: [
+                    { panelId: 'center-workspace', contentType: 'projects', viewMode: 'cards', position: 'center' },
+                    { panelId: 'selection-inspector', position: 'right', bound: true },
+                ],
+            },
         ],
     },
     {
@@ -64,6 +99,26 @@ export const BUILT_IN_WORKSPACES: WorkspacePreset[] = [
             { panelId: 'selection-inspector', position: 'right', bound: true },
             { panelId: 'composer-workbench', position: 'bottom' },
         ],
+        subviews: [
+            {
+                id: 'workflow',
+                label: 'Workflow',
+                panels: [
+                    { panelId: 'center-workspace', contentType: 'projects', viewMode: 'workflow', position: 'center' },
+                    { panelId: 'selection-inspector', position: 'right', bound: true },
+                    { panelId: 'composer-workbench', position: 'bottom' },
+                ],
+            },
+            {
+                id: 'list',
+                label: 'List',
+                panels: [
+                    { panelId: 'center-workspace', contentType: 'projects', viewMode: 'list', position: 'center' },
+                    { panelId: 'selection-inspector', position: 'right', bound: true },
+                    { panelId: 'composer-workbench', position: 'bottom' },
+                ],
+            },
+        ],
     },
     {
         id: 'review',
@@ -76,6 +131,16 @@ export const BUILT_IN_WORKSPACES: WorkspacePreset[] = [
             { panelId: 'center-workspace', contentType: 'projects', viewMode: 'log', position: 'center' },
             { panelId: 'selection-inspector', position: 'right', bound: true },
         ],
+        subviews: [
+            {
+                id: 'log',
+                label: 'Log',
+                panels: [
+                    { panelId: 'center-workspace', contentType: 'projects', viewMode: 'log', position: 'center' },
+                    { panelId: 'selection-inspector', position: 'right', bound: true },
+                ],
+            },
+        ],
     },
     {
         id: 'deliver',
@@ -86,6 +151,15 @@ export const BUILT_IN_WORKSPACES: WorkspacePreset[] = [
         isBuiltIn: true,
         panels: [
             { panelId: 'center-workspace', contentType: 'export', position: 'center' },
+        ],
+        subviews: [
+            {
+                id: 'export',
+                label: 'Export',
+                panels: [
+                    { panelId: 'center-workspace', contentType: 'export', position: 'center' },
+                ],
+            },
         ],
     },
     {
@@ -100,6 +174,18 @@ export const BUILT_IN_WORKSPACES: WorkspacePreset[] = [
             { panelId: 'project-panel', position: 'center', bound: true },
             { panelId: 'project-panel', position: 'center', bound: true },
             { panelId: 'mail-panel', position: 'right' },
+        ],
+        subviews: [
+            {
+                id: 'dashboard',
+                label: 'Dashboard',
+                panels: [
+                    { panelId: 'project-panel', position: 'center', bound: true },
+                    { panelId: 'project-panel', position: 'center', bound: true },
+                    { panelId: 'project-panel', position: 'center', bound: true },
+                    { panelId: 'mail-panel', position: 'right' },
+                ],
+            },
         ],
     },
 ];

--- a/packages/ui/src/molecules/Menu.tsx
+++ b/packages/ui/src/molecules/Menu.tsx
@@ -7,6 +7,7 @@
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { clsx } from 'clsx';
+import { ChevronRight } from 'lucide-react';
 import { type ReactNode, type ElementType, type ComponentPropsWithoutRef } from 'react';
 
 export interface MenuProps {
@@ -153,8 +154,87 @@ function MenuDivider({ className }: MenuDividerProps) {
     return <DropdownMenu.Separator className={clsx('my-1 h-px bg-slate-200', className)} />;
 }
 
+// ---------------------------------------------------------------------------
+// Submenu components
+// ---------------------------------------------------------------------------
+
+export interface MenuSubProps {
+    children: ReactNode;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+}
+
+function MenuSub({ children, open, onOpenChange }: MenuSubProps) {
+    return (
+        <DropdownMenu.Sub open={open} onOpenChange={onOpenChange}>
+            {children}
+        </DropdownMenu.Sub>
+    );
+}
+
+export interface MenuSubTriggerProps {
+    children: ReactNode;
+    leftSection?: ReactNode;
+    className?: string;
+    disabled?: boolean;
+}
+
+function MenuSubTrigger({ children, leftSection, className, disabled }: MenuSubTriggerProps) {
+    return (
+        <DropdownMenu.SubTrigger
+            disabled={disabled}
+            className={clsx(
+                'w-full flex items-center gap-2 px-3 py-2 text-sm font-sans text-left transition-colors outline-none',
+                'focus:bg-slate-100 cursor-pointer',
+                'data-[state=open]:bg-slate-100',
+                'data-[disabled]:text-slate-400 data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none',
+                !disabled && 'text-slate-700',
+                className
+            )}
+        >
+            {leftSection && <span className="flex-shrink-0">{leftSection}</span>}
+            <span className="flex-1">{children}</span>
+            <ChevronRight size={14} className="flex-shrink-0 text-slate-400" />
+        </DropdownMenu.SubTrigger>
+    );
+}
+
+export interface MenuSubContentProps {
+    children: ReactNode;
+    className?: string;
+    sideOffset?: number;
+    alignOffset?: number;
+}
+
+function MenuSubContent({ children, className, sideOffset = 2, alignOffset = -5 }: MenuSubContentProps) {
+    return (
+        <DropdownMenu.Portal>
+            <DropdownMenu.SubContent
+                className={clsx(
+                    'z-50 min-w-[160px] py-1 bg-white rounded-lg border border-slate-200 shadow-lg font-sans',
+                    'data-[state=open]:animate-in data-[state=closed]:animate-out',
+                    'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+                    'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+                    'data-[side=bottom]:slide-in-from-top-2',
+                    'data-[side=left]:slide-in-from-right-2',
+                    'data-[side=right]:slide-in-from-left-2',
+                    'data-[side=top]:slide-in-from-bottom-2',
+                    className
+                )}
+                sideOffset={sideOffset}
+                alignOffset={alignOffset}
+            >
+                {children}
+            </DropdownMenu.SubContent>
+        </DropdownMenu.Portal>
+    );
+}
+
 Menu.Target = MenuTarget;
 Menu.Dropdown = MenuDropdown;
 Menu.Item = MenuItem;
 Menu.Label = MenuLabel;
 Menu.Divider = MenuDivider;
+Menu.Sub = MenuSub;
+Menu.SubTrigger = MenuSubTrigger;
+Menu.SubContent = MenuSubContent;


### PR DESCRIPTION



<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #298**
  * **PR #299**
    * **PR #300**
      * **PR #301**
        * **PR #302** 👈
          * **PR #303**
            * **PR #304**
              * **PR #305**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->

## Summary by Sourcery

Add workspace subview support with nested submenu navigation in the workspace dropdown and propagate subview awareness through workspace presets and state management.

New Features:
- Introduce nested submenu components in the shared Menu molecule to support submenus within dropdowns.
- Add subview support to workspace presets so built-in workspaces can define multiple named layouts under a single workspace.
- Enable selecting and persisting workspace subviews via the workspace store and dropdown UI, including passing subview IDs when applying workspaces.

Enhancements:
- Refine workspace dropdown entries to render multi-subview workspaces as submenus and single-subview/legacy workspaces as flat items while preserving delete actions.