### PR TITLE
feat: scoped custom workspace management with per-submenu save

### DIFF
--- a/frontend/src/types/workspace.ts
+++ b/frontend/src/types/workspace.ts
@@ -65,6 +65,8 @@ export interface WorkspacePreset {
     scope: WorkspaceScope;
     /** Whether this is a built-in workspace (vs user-created) */
     isBuiltIn: boolean;
+    /** Scopes this custom workspace under a built-in workspace's submenu */
+    parentWorkspaceId?: string;
     /** @deprecated Use subviews instead. Kept for backward compat with custom workspaces. */
     panels: WorkspacePanelConfig[];
     /** Named sub-configurations. Built-in workspaces should use this. */


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #298**
  * **PR #299**
    * **PR #300**
      * **PR #301**
        * **PR #302**
          * **PR #303** 👈
            * **PR #304**
              * **PR #305**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Scoped custom workspace management with per-submenu save

### What Changed
- Built-in workspaces show nested submenus combining their built-in subviews and any custom views scoped to that workspace; each submenu includes a "Save current" action to save the current panel arrangement directly into that workspace's submenu.
- New option to scope a custom workspace under a specific built-in workspace (parentWorkspaceId) and pick a color when saving; legacy custom workspaces without a parent remain available under a separate "Custom" section.
- Inline menu actions let users duplicate or delete custom workspaces; built-in subviews can be duplicated into new custom views scoped to the parent workspace.

### Impact
`✅ Save custom view under specific workspace`
`✅ Duplicate subviews into scoped custom views`
`✅ Delete or clone custom views directly from the workspace menu`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
