### PR TITLE
feat: expand workspace color palette to full Tailwind v4 chromatic set

### DIFF
--- a/frontend/src/ui/layout/AddWorkspaceDialog.tsx
+++ b/frontend/src/ui/layout/AddWorkspaceDialog.tsx
@@ -12,13 +12,7 @@ import { Folder } from 'lucide-react';
 import { Modal, Button, Text, Inline } from '@autoart/ui';
 import { useWorkspaceStore } from '../../stores/workspaceStore';
 import { BUILT_IN_WORKSPACES } from '../../workspace/workspacePresets';
-import { WORKSPACE_COLORS, type WorkspaceColorName } from '../../workspace/workspaceColors';
-
-const COLOR_NAMES: WorkspaceColorName[] = [
-    'red', 'orange', 'amber', 'yellow', 'lime', 'green', 'emerald', 'teal', 'cyan',
-    'sky', 'blue', 'indigo', 'violet', 'purple', 'fuchsia', 'pink', 'rose',
-    'slate', 'gray', 'zinc', 'neutral', 'stone',
-];
+import { WORKSPACE_COLORS, BASIC_COLOR_NAMES, ALL_COLOR_NAMES, type WorkspaceColorName } from '../../workspace/workspaceColors';
 
 interface AddWorkspaceDialogProps {
     open: boolean;
@@ -31,6 +25,8 @@ export function AddWorkspaceDialog({ open, onClose, parentWorkspaceId, defaultCo
     const [name, setName] = useState('');
     const [color, setColor] = useState<WorkspaceColorName>((defaultColor as WorkspaceColorName) ?? 'slate');
     const [error, setError] = useState<string | null>(null);
+    const [showAllColors, setShowAllColors] = useState(false);
+    const visibleColors = showAllColors ? ALL_COLOR_NAMES : BASIC_COLOR_NAMES;
 
     const parentLabel = parentWorkspaceId
         ? BUILT_IN_WORKSPACES.find(w => w.id === parentWorkspaceId)?.label
@@ -74,6 +70,7 @@ export function AddWorkspaceDialog({ open, onClose, parentWorkspaceId, defaultCo
             setName('');
             setColor((defaultColor as WorkspaceColorName) ?? 'slate');
             setError(null);
+            setShowAllColors(false);
             onClose();
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Failed to save workspace');
@@ -84,6 +81,7 @@ export function AddWorkspaceDialog({ open, onClose, parentWorkspaceId, defaultCo
         setName('');
         setColor((defaultColor as WorkspaceColorName) ?? 'slate');
         setError(null);
+        setShowAllColors(false);
         onClose();
     }, [defaultColor, onClose]);
 
@@ -133,11 +131,20 @@ export function AddWorkspaceDialog({ open, onClose, parentWorkspaceId, defaultCo
 
                 {/* Color picker */}
                 <div>
-                    <label className="block text-sm font-medium text-slate-700 mb-2">
-                        Color
-                    </label>
+                    <div className="flex items-center justify-between mb-2">
+                        <label className="block text-sm font-medium text-slate-700">
+                            Color
+                        </label>
+                        <button
+                            type="button"
+                            onClick={() => setShowAllColors(!showAllColors)}
+                            className="text-xs text-slate-500 hover:text-slate-700 transition-colors"
+                        >
+                            {showAllColors ? 'Fewer' : 'More'}
+                        </button>
+                    </div>
                     <div className="flex flex-wrap gap-2">
-                        {COLOR_NAMES.map((c) => {
+                        {visibleColors.map((c) => {
                             const classes = WORKSPACE_COLORS[c];
                             const isSelected = c === color;
                             return (

--- a/frontend/src/ui/layout/WorkspaceDropdown.tsx
+++ b/frontend/src/ui/layout/WorkspaceDropdown.tsx
@@ -10,7 +10,7 @@
 import { ChevronDown, Copy, Dna, Folder, Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 
-import { Button } from '@autoart/ui';
+import { Button, type ButtonColor } from '@autoart/ui';
 import { Menu } from '@autoart/ui';
 import { useWorkspaceStore, useActiveWorkspaceId, useActiveSubviewId, useCustomWorkspaces } from '../../stores/workspaceStore';
 import { BUILT_IN_WORKSPACES } from '../../workspace/workspacePresets';
@@ -51,29 +51,28 @@ const WORKSPACE_COLOR_CONFIG: Record<string, { icon: string; active: string }> =
 const DEFAULT_COLOR = 'slate';
 
 /**
- * Maps workspace colors to Button component's supported colors.
- * Button only supports: 'gray' | 'blue' | 'violet' | 'yellow'
- * Amber and orange both map to yellow — closest available match.
+ * Maps workspace colors to Button component colors.
+ * Each workspace color maps to the closest available button color.
  */
-const BUTTON_COLOR_MAP: Record<string, 'gray' | 'blue' | 'violet' | 'yellow'> = {
+const BUTTON_COLOR_MAP: Record<string, ButtonColor> = {
     // Chromatic — warm to cool
-    red: 'violet',
-    orange: 'yellow',
+    red: 'red',
+    orange: 'orange',
     amber: 'yellow',
     yellow: 'yellow',
-    lime: 'blue',
-    green: 'blue',
-    emerald: 'blue',
-    teal: 'blue',
-    cyan: 'blue',
-    sky: 'blue',
+    lime: 'green',
+    green: 'green',
+    emerald: 'teal',
+    teal: 'teal',
+    cyan: 'cyan',
+    sky: 'cyan',
     blue: 'blue',
-    indigo: 'violet',
+    indigo: 'indigo',
     violet: 'violet',
     purple: 'violet',
-    fuchsia: 'violet',
-    pink: 'violet',
-    rose: 'violet',
+    fuchsia: 'pink',
+    pink: 'pink',
+    rose: 'rose',
     // Neutrals
     slate: 'gray',
     gray: 'gray',
@@ -82,7 +81,7 @@ const BUTTON_COLOR_MAP: Record<string, 'gray' | 'blue' | 'violet' | 'yellow'> = 
     stone: 'gray',
 };
 
-function getButtonColor(workspaceColor: string): 'gray' | 'blue' | 'violet' | 'yellow' {
+function getButtonColor(workspaceColor: string): ButtonColor {
     return BUTTON_COLOR_MAP[workspaceColor] ?? 'gray';
 }
 

--- a/frontend/src/workspace/workspaceColors.ts
+++ b/frontend/src/workspace/workspaceColors.ts
@@ -248,6 +248,18 @@ export const WORKSPACE_COLORS: Record<WorkspaceColorName, WorkspaceColorClasses>
     },
 };
 
+/** 8 curated defaults shown by default in pickers */
+export const BASIC_COLOR_NAMES: WorkspaceColorName[] = [
+    'red', 'orange', 'amber', 'green', 'cyan', 'blue', 'purple', 'pink',
+];
+
+/** Full ordered palette (warm → cool → neutral) */
+export const ALL_COLOR_NAMES: WorkspaceColorName[] = [
+    'red', 'orange', 'amber', 'yellow', 'lime', 'green', 'emerald', 'teal', 'cyan',
+    'sky', 'blue', 'indigo', 'violet', 'purple', 'fuchsia', 'pink', 'rose',
+    'slate', 'gray', 'zinc', 'neutral', 'stone',
+];
+
 /** Get color classes for a workspace color, with slate fallback */
 export function getWorkspaceColorClasses(color: string | null | undefined): WorkspaceColorClasses {
     if (color && color in WORKSPACE_COLORS) {

--- a/packages/ui/src/atoms/Button.tsx
+++ b/packages/ui/src/atoms/Button.tsx
@@ -1,10 +1,12 @@
 import { clsx } from 'clsx';
 import { forwardRef, ButtonHTMLAttributes } from 'react';
 
+export type ButtonColor = 'gray' | 'red' | 'orange' | 'yellow' | 'green' | 'teal' | 'cyan' | 'blue' | 'indigo' | 'violet' | 'pink' | 'rose';
+
 interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
     variant?: 'primary' | 'secondary' | 'ghost' | 'danger' | 'light' | 'subtle';
     size?: 'xs' | 'sm' | 'md' | 'lg';
-    color?: 'gray' | 'blue' | 'violet' | 'yellow';
+    color?: ButtonColor;
     leftSection?: React.ReactNode;
     rightSection?: React.ReactNode;
 }
@@ -14,17 +16,49 @@ const colorStyles = {
         light: 'bg-slate-100 text-slate-700 hover:bg-slate-200',
         subtle: 'text-slate-600 hover:bg-slate-100',
     },
+    red: {
+        light: 'bg-red-50 text-red-700 hover:bg-red-100',
+        subtle: 'text-red-600 hover:bg-red-50',
+    },
+    orange: {
+        light: 'bg-orange-50 text-orange-700 hover:bg-orange-100',
+        subtle: 'text-orange-600 hover:bg-orange-50',
+    },
+    yellow: {
+        light: 'bg-amber-50 text-amber-700 hover:bg-amber-100',
+        subtle: 'text-amber-600 hover:bg-amber-50',
+    },
+    green: {
+        light: 'bg-green-50 text-green-700 hover:bg-green-100',
+        subtle: 'text-green-600 hover:bg-green-50',
+    },
+    teal: {
+        light: 'bg-teal-50 text-teal-700 hover:bg-teal-100',
+        subtle: 'text-teal-600 hover:bg-teal-50',
+    },
+    cyan: {
+        light: 'bg-cyan-50 text-cyan-700 hover:bg-cyan-100',
+        subtle: 'text-cyan-600 hover:bg-cyan-50',
+    },
     blue: {
         light: 'bg-blue-50 text-blue-700 hover:bg-blue-100',
         subtle: 'text-blue-600 hover:bg-blue-50',
+    },
+    indigo: {
+        light: 'bg-indigo-50 text-indigo-700 hover:bg-indigo-100',
+        subtle: 'text-indigo-600 hover:bg-indigo-50',
     },
     violet: {
         light: 'bg-violet-50 text-violet-700 hover:bg-violet-100',
         subtle: 'text-violet-600 hover:bg-violet-50',
     },
-    yellow: {
-        light: 'bg-amber-50 text-amber-700 hover:bg-amber-100',
-        subtle: 'text-amber-600 hover:bg-amber-50',
+    pink: {
+        light: 'bg-pink-50 text-pink-700 hover:bg-pink-100',
+        subtle: 'text-pink-600 hover:bg-pink-50',
+    },
+    rose: {
+        light: 'bg-rose-50 text-rose-700 hover:bg-rose-100',
+        subtle: 'text-rose-600 hover:bg-rose-50',
     },
 };
 


### PR DESCRIPTION
## **User description**
- feat: expand workspace color palette to full Tailwind v4 chromatic set
- feat: add basic/expanded color picker toggle and expand Button color palette


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #298**
  * **PR #299**
    * **PR #300**
      * **PR #301**
        * **PR #302**
          * **PR #303**
            * **PR #304** 👈
              * **PR #305**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Expand workspace color palette and add a toggle to show basic/expanded pickers

### What Changed
- Workspace color set expanded from 8 to a full 22-color Tailwind palette; new warm→cool→neutral colors are available throughout the UI
- Color picker in the "Save Workspace" dialog now shows 8 curated default colors with a "More"/"Fewer" toggle to reveal or hide the full 22-color palette; selection resets when the dialog closes
- Buttons and the workspace dropdown now use the expanded palette and a new mapping so button styles better match the selected workspace color

### Impact
`✅ More workspace color choices`
`✅ More accurate button color matches`
`✅ Shorter time to find desired workspace color`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
