### PR TITLE
fix: address review feedback across stack PRs #299-#303

### DIFF
--- a/frontend/src/stores/workspaceStore.ts
+++ b/frontend/src/stores/workspaceStore.ts
@@ -591,7 +591,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
 export const useOpenPanelIds = () => useWorkspaceStore((s) => s.openPanelIds);
 export const useLayout = () => useWorkspaceStore((s) => s.layout);
 export const useActiveWorkspaceId = () => useWorkspaceStore((s) => s.activeWorkspaceId);
-export const useActiveSubviewId = () => useWorkspaceStore((s) => s.activeSubviewId);
+export const useActiveSubviewId = () => useWorkspaceStore((s) => s.activeWorkspaceId ? s.activeSubviewId : null);
 export const useCustomWorkspaces = () => useWorkspaceStore((s) => s.customWorkspaces);
 export const useAllWorkspaces = () => useWorkspaceStore((s) => s.getAllWorkspaces());
 export const usePendingPanelPositions = () => useWorkspaceStore((s) => s.pendingPanelPositions);

--- a/frontend/src/styles/dockview-theme.css
+++ b/frontend/src/styles/dockview-theme.css
@@ -88,6 +88,7 @@
 .dockview-theme-light .dv-tab.dv-active-tab .dv-default-tab-content {
   background-color: transparent;
   color: var(--ws-tab-fg-active);
+  padding: 0;
 }
 
 .dockview-theme-light .dv-tab.dv-inactive-tab .dv-default-tab-content {

--- a/frontend/src/ui/inspector/MappingsPanel.tsx
+++ b/frontend/src/ui/inspector/MappingsPanel.tsx
@@ -163,25 +163,26 @@ function MappingRow({
 
             {/* Actions menu */}
             {onUnlink && (
-                <Menu>
-                    <Menu.Target>
-                        <button
-                            onClick={(e) => e.stopPropagation()}
-                            className="p-1 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded transition-colors"
-                        >
-                            <MoreHorizontal size={14} />
-                        </button>
-                    </Menu.Target>
-                    <Menu.Dropdown align="end">
-                        <Menu.Item
-                            leftSection={<Unlink size={12} />}
-                            className="text-red-600"
-                            onClick={() => onUnlink(entry)}
-                        >
-                            Unlink
-                        </Menu.Item>
-                    </Menu.Dropdown>
-                </Menu>
+                <div onClick={(e) => e.stopPropagation()}>
+                    <Menu>
+                        <Menu.Target>
+                            <button
+                                className="p-1 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded transition-colors"
+                            >
+                                <MoreHorizontal size={14} />
+                            </button>
+                        </Menu.Target>
+                        <Menu.Dropdown align="end">
+                            <Menu.Item
+                                leftSection={<Unlink size={12} />}
+                                className="text-red-600"
+                                onClick={() => onUnlink(entry)}
+                            >
+                                Unlink
+                            </Menu.Item>
+                        </Menu.Dropdown>
+                    </Menu>
+                </div>
             )}
 
             {/* Navigate arrow */}

--- a/frontend/src/ui/layout/AddWorkspaceDialog.tsx
+++ b/frontend/src/ui/layout/AddWorkspaceDialog.tsx
@@ -14,6 +14,12 @@ import { useWorkspaceStore } from '../../stores/workspaceStore';
 import { BUILT_IN_WORKSPACES } from '../../workspace/workspacePresets';
 import { WORKSPACE_COLORS, BASIC_COLOR_NAMES, ALL_COLOR_NAMES, type WorkspaceColorName } from '../../workspace/workspaceColors';
 
+function toValidColor(value: string | undefined): WorkspaceColorName {
+    return (ALL_COLOR_NAMES as readonly string[]).includes(value ?? '')
+        ? (value as WorkspaceColorName)
+        : 'slate';
+}
+
 interface AddWorkspaceDialogProps {
     open: boolean;
     onClose: () => void;
@@ -23,7 +29,7 @@ interface AddWorkspaceDialogProps {
 
 export function AddWorkspaceDialog({ open, onClose, parentWorkspaceId, defaultColor }: AddWorkspaceDialogProps) {
     const [name, setName] = useState('');
-    const [color, setColor] = useState<WorkspaceColorName>((defaultColor as WorkspaceColorName) ?? 'slate');
+    const [color, setColor] = useState<WorkspaceColorName>(toValidColor(defaultColor));
     const [error, setError] = useState<string | null>(null);
     const [showAllColors, setShowAllColors] = useState(false);
     const visibleColors = showAllColors ? ALL_COLOR_NAMES : BASIC_COLOR_NAMES;
@@ -68,7 +74,7 @@ export function AddWorkspaceDialog({ open, onClose, parentWorkspaceId, defaultCo
             });
             // Reset and close only on success
             setName('');
-            setColor((defaultColor as WorkspaceColorName) ?? 'slate');
+            setColor(toValidColor(defaultColor));
             setError(null);
             setShowAllColors(false);
             onClose();
@@ -79,7 +85,7 @@ export function AddWorkspaceDialog({ open, onClose, parentWorkspaceId, defaultCo
 
     const handleClose = useCallback(() => {
         setName('');
-        setColor((defaultColor as WorkspaceColorName) ?? 'slate');
+        setColor(toValidColor(defaultColor));
         setError(null);
         setShowAllColors(false);
         onClose();

--- a/frontend/src/ui/layout/WorkspaceDropdown.tsx
+++ b/frontend/src/ui/layout/WorkspaceDropdown.tsx
@@ -169,7 +169,7 @@ function WorkspaceMenuEntry({
     const Icon = workspace.icon ?? Folder;
     const colorClasses = getIconColorClass(workspace.color);
     const subviewCount = workspace.subviews?.length ?? 0;
-    const hasSubmenu = subviewCount > 1 || customChildren.length > 0;
+    const hasSubmenu = subviewCount > 0 || customChildren.length > 0;
 
     const iconElement = (
         <span className={`p-1 rounded ${colorClasses}`}>
@@ -384,6 +384,7 @@ export function WorkspaceDropdown() {
             </Menu>
 
             <AddWorkspaceDialog
+                key={dialogParentId ?? 'global'}
                 open={dialogOpen}
                 onClose={() => {
                     setDialogOpen(false);

--- a/frontend/src/ui/mail/EmailActionsMenu.tsx
+++ b/frontend/src/ui/mail/EmailActionsMenu.tsx
@@ -33,47 +33,51 @@ export function EmailActionsMenu({ email, onAction }: EmailActionsMenuProps) {
         informationalMutation.isPending;
 
     return (
-        <Menu>
-            <Menu.Target>
-                <button
-                    onClick={(e) => e.stopPropagation()}
-                    disabled={isPending}
-                    className="p-1.5 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded transition-colors disabled:opacity-50"
-                >
-                    {isPending ? (
-                        <Loader2 size={14} className="animate-spin" />
-                    ) : (
-                        <MoreHorizontal size={14} />
-                    )}
-                </button>
-            </Menu.Target>
-            <Menu.Dropdown align="end">
-                <Menu.Item
-                    leftSection={<AlertTriangle size={14} className="text-red-500" />}
-                    onClick={() => {
-                        actionRequiredMutation.mutate(email.id, { onSuccess: onAction });
-                    }}
-                >
-                    Action Required
-                </Menu.Item>
-                <Menu.Item
-                    leftSection={<Info size={14} className="text-blue-500" />}
-                    onClick={() => {
-                        informationalMutation.mutate(email.id, { onSuccess: onAction });
-                    }}
-                >
-                    Informational
-                </Menu.Item>
-                <Menu.Divider />
-                <Menu.Item
-                    leftSection={<Archive size={14} className="text-slate-400" />}
-                    onClick={() => {
-                        archiveMutation.mutate(email.id, { onSuccess: onAction });
-                    }}
-                >
-                    Archive
-                </Menu.Item>
-            </Menu.Dropdown>
-        </Menu>
+        <div onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
+            <Menu>
+                <Menu.Target>
+                    <button
+                        disabled={isPending}
+                        className="p-1.5 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded transition-colors disabled:opacity-50"
+                    >
+                        {isPending ? (
+                            <Loader2 size={14} className="animate-spin" />
+                        ) : (
+                            <MoreHorizontal size={14} />
+                        )}
+                    </button>
+                </Menu.Target>
+                <Menu.Dropdown align="end">
+                    <Menu.Item
+                        leftSection={<AlertTriangle size={14} className="text-red-500" />}
+                        disabled={isPending}
+                        onClick={() => {
+                            actionRequiredMutation.mutate(email.id, { onSuccess: onAction });
+                        }}
+                    >
+                        Action Required
+                    </Menu.Item>
+                    <Menu.Item
+                        leftSection={<Info size={14} className="text-blue-500" />}
+                        disabled={isPending}
+                        onClick={() => {
+                            informationalMutation.mutate(email.id, { onSuccess: onAction });
+                        }}
+                    >
+                        Informational
+                    </Menu.Item>
+                    <Menu.Divider />
+                    <Menu.Item
+                        leftSection={<Archive size={14} className="text-slate-400" />}
+                        disabled={isPending}
+                        onClick={() => {
+                            archiveMutation.mutate(email.id, { onSuccess: onAction });
+                        }}
+                    >
+                        Archive
+                    </Menu.Item>
+                </Menu.Dropdown>
+            </Menu>
+        </div>
     );
 }

--- a/frontend/src/workspace/workspacePresets.ts
+++ b/frontend/src/workspace/workspacePresets.ts
@@ -171,8 +171,6 @@ export const BUILT_IN_WORKSPACES: WorkspacePreset[] = [
         isBuiltIn: true,
         panels: [
             { panelId: 'project-panel', position: 'center', bound: true },
-            { panelId: 'project-panel', position: 'center', bound: true },
-            { panelId: 'project-panel', position: 'center', bound: true },
             { panelId: 'mail-panel', position: 'right' },
         ],
         subviews: [
@@ -180,8 +178,6 @@ export const BUILT_IN_WORKSPACES: WorkspacePreset[] = [
                 id: 'dashboard',
                 label: 'Dashboard',
                 panels: [
-                    { panelId: 'project-panel', position: 'center', bound: true },
-                    { panelId: 'project-panel', position: 'center', bound: true },
                     { panelId: 'project-panel', position: 'center', bound: true },
                     { panelId: 'mail-panel', position: 'right' },
                 ],

--- a/packages/ui/src/molecules/Menu.tsx
+++ b/packages/ui/src/molecules/Menu.tsx
@@ -113,7 +113,7 @@ function MenuItem<C extends ElementType = 'button'>({
             <Component
                 {...rest}
                 className={clsx(
-                    'w-full flex items-center gap-2 px-3 py-2 text-sm font-sans text-left transition-colors outline-none',
+                    'w-full flex items-center gap-2 px-3 py-2 text-sm text-left transition-colors outline-none',
                     'focus:bg-slate-100 cursor-pointer',
                     'data-[disabled]:text-slate-400 data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none',
                     !disabled && 'text-slate-700',
@@ -137,7 +137,7 @@ function MenuLabel({ children, className }: MenuLabelProps) {
     return (
         <DropdownMenu.Label
             className={clsx(
-                'px-3 py-1.5 text-xs font-sans font-medium text-slate-500 uppercase tracking-wider',
+                'px-3 py-1.5 text-xs font-medium text-slate-500 uppercase tracking-wider',
                 className
             )}
         >
@@ -184,7 +184,7 @@ function MenuSubTrigger({ children, leftSection, className, disabled }: MenuSubT
         <DropdownMenu.SubTrigger
             disabled={disabled}
             className={clsx(
-                'w-full flex items-center gap-2 px-3 py-2 text-sm font-sans text-left transition-colors outline-none',
+                'w-full flex items-center gap-2 px-3 py-2 text-sm text-left transition-colors outline-none',
                 'focus:bg-slate-100 cursor-pointer',
                 'data-[state=open]:bg-slate-100',
                 'data-[disabled]:text-slate-400 data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none',


### PR DESCRIPTION
## **User description**
- Fix active tab padding inconsistency in dockview theme (#299)
- Centralize font-sans on Menu container, remove from child items (#300)
- Fix stopPropagation blocking menu open in EmailActionsMenu (#301)
- Fix stopPropagation blocking unlink menu in MappingsPanel (#301)
- Add disabled state to EmailActionsMenu items during mutations (#301)
- Add propagation barrier for keyboard events on mail rows (#301)
- Guard useActiveSubviewId when no active workspace (#302)
- Fix duplicate project-panel entries in desk preset (#302)
- Enable submenu for single-subview workspaces to show Save action (#302/#303)
- Validate defaultColor against color palette in AddWorkspaceDialog (#303)
- Key AddWorkspaceDialog by parentId to prevent stale color state (#303)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #298**
  * **PR #299**
    * **PR #300**
      * **PR #301**
        * **PR #302**
          * **PR #303**
            * **PR #304**
              * **PR #305** 👈

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Fix workspace color defaults, menu interaction, duplicate desk panels, and active tab padding

### What Changed
- AddWorkspace dialog now validates and uses a safe default color so new-workspace color never becomes invalid or stale when opened for different parents
- Workspace dropdown dialog is keyed by parent so the dialog shows the correct default color and parent context when opened repeatedly
- Desk preset no longer contains duplicate project-panel entries, preventing duplicate panels from appearing
- Menu and submenu interactions no longer get blocked by stopPropagation: menu buttons in email rows and mapping rows open reliably, and email action items are disabled while their background operations run and show a small loader
- Active tab label padding in the dockview theme adjusted so the selected tab aligns visually with the panel
- Subview id selector now returns null when there is no active workspace to avoid incorrect active-subview state

### Impact
`✅ Clearer workspace color selection when saving a workspace`
`✅ Fewer duplicate panels when selecting the Desk workspace`
`✅ Menus open reliably and show disabled state during async actions`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
