### PR TITLE
fix: remove swoopy corner hacks, restore dockview overflow

### DIFF
--- a/frontend/src/styles/dockview-theme.css
+++ b/frontend/src/styles/dockview-theme.css
@@ -41,27 +41,9 @@
   position: relative;
   background-image: none !important;
   background-size: auto;
-  padding: 0 var(--ws-tab-radius);
 }
 
-/* Overflow stack fix — swoopy pseudo-elements extend ~8px beyond the tab.
-   All three inner layers (tabs-container, dv-scrollable, tabs-and-actions-container)
-   must be overflow:visible so nothing clips the ::before/::after concave corners.
-   The outermost clip boundary is .dv-groupview (overflow:hidden, set by dockview),
-   which is large enough that the pseudo-elements stay well within its bounds. */
-.dockview-theme-light .dv-scrollable {
-  overflow: visible !important;
-}
-
-.dockview-theme-light .dv-tabs-container {
-  overflow: visible !important;
-}
-
-.dockview-theme-light .dv-react-part {
-  overflow: visible;
-}
-
-/* === Tab base (inverse-radius swoopy tabs) === */
+/* === Tab base (lifted tabs) === */
 
 .dockview-theme-light .dv-tab {
   font-family: var(--font-sans);
@@ -113,38 +95,8 @@
 }
 
 /* Suppress dockview's native ::before divider on the active tab */
-.dockview-theme-light .dv-tab.dv-active-tab::before {
+.dockview-theme-light .dv-tabs-container.dv-horizontal .dv-tab.dv-active-tab::before {
   content: none !important;
-}
-
-/* Suppress dockview's native ::after focus outline on the active tab */
-.dockview-theme-light .dv-tab.dv-active-tab::after {
-  content: none !important;
-}
-
-/* Swoopy concave corners — real DOM elements to bypass dockview styleInject conflicts */
-.ws-tab-corner {
-  display: none;
-  position: absolute;
-  bottom: -1px;
-  width: var(--ws-tab-radius);
-  height: var(--ws-tab-radius);
-  pointer-events: none;
-  z-index: 2;
-}
-
-.dockview-theme-light .dv-active-tab .ws-tab-corner {
-  display: block;
-}
-
-.ws-tab-corner-left {
-  left: calc(-1 * var(--ws-tab-radius));
-  background: radial-gradient(circle at 100% 0, transparent var(--ws-tab-radius), var(--ws-tab-bg-active) calc(var(--ws-tab-radius) + 0.5px));
-}
-
-.ws-tab-corner-right {
-  right: calc(-1 * var(--ws-tab-radius));
-  background: radial-gradient(circle at 0 0, transparent var(--ws-tab-radius), var(--ws-tab-bg-active) calc(var(--ws-tab-radius) + 0.5px));
 }
 
 .dockview-theme-light .dv-tab.dv-active-tab:hover {

--- a/frontend/src/ui/layout/MainLayout.tsx
+++ b/frontend/src/ui/layout/MainLayout.tsx
@@ -325,44 +325,9 @@ function WatermarkComponent() {
 // TAB COMPONENT
 // ============================================================================
 
-/**
- * Inject swoopy corner spans directly onto the `.dv-tab` ancestor via DOM API.
- * Dockview wraps React tab content in `.dv-react-part` (100% width/height),
- * which traps absolutely-positioned children. By appending corners as siblings
- * of `.dv-react-part` they become direct children of `.dv-tab` (position: relative),
- * letting the existing CSS position them correctly.
- */
-function useSwoopyCorners(innerRef: React.RefObject<HTMLElement | null>) {
-  useEffect(() => {
-    const el = innerRef.current;
-    if (!el) return;
-
-    const tab = el.closest('.dv-tab');
-    if (!tab) return;
-
-    const left = document.createElement('span');
-    left.className = 'ws-tab-corner ws-tab-corner-left';
-    left.setAttribute('aria-hidden', 'true');
-
-    const right = document.createElement('span');
-    right.className = 'ws-tab-corner ws-tab-corner-right';
-    right.setAttribute('aria-hidden', 'true');
-
-    tab.appendChild(left);
-    tab.appendChild(right);
-
-    return () => {
-      left.remove();
-      right.remove();
-    };
-  }, []);
-}
-
 function IconTab(props: IDockviewPanelHeaderProps) {
   const { api } = props;
   const closePanel = useWorkspaceStore((s) => s.closePanel);
-  const tabContentRef = useRef<HTMLDivElement>(null);
-  useSwoopyCorners(tabContentRef);
 
   // Get component type from dynamic panel ID (e.g., "project-panel-123" -> "project-panel")
   const getComponentType = (panelId: string): PanelId => {
@@ -399,7 +364,6 @@ function IconTab(props: IDockviewPanelHeaderProps) {
 
   return (
     <div
-      ref={tabContentRef}
       className={`flex items-center gap-2 text-current overflow-hidden w-full group ${boundColorClasses}`}
     >
       <div className="flex items-center gap-2 flex-1 overflow-hidden min-w-0">


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #307**
  * **PR #308** 👈
    * **PR #309**
      * **PR #310**
        * **PR #311**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Remove DOM-injected tab corner hacks and restore dockview overflow so tabs render cleanly

### What Changed
- Eliminates runtime injection of decorative corner spans into tab DOM, so header elements are no longer altered by the layout code
- Removes CSS that forced multiple tab container elements to be overflow: visible and replaces the concave “swoopy” tab styling with a simpler lifted tab appearance
- Restores dockview's native overflow/scrolling behavior for the tab strip and adjusts active-tab divider suppression so tabs no longer rely on injected elements

### Impact
`✅ Fewer layout glitches in the tab strip when resizing or scrolling`
`✅ No unexpected DOM elements in tab headers`
`✅ Restored native tab overflow/scroll behavior`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
