### PR TITLE
feat: switch to dockview v4 theme prop, fix drop zone glow

### DIFF
--- a/frontend/src/styles/dockview-theme.css
+++ b/frontend/src/styles/dockview-theme.css
@@ -158,6 +158,12 @@
 
 /* === Drop target glow === */
 
+/* Allow drop target glow shadow to extend beyond the container boundary.
+   The container uses pointer-events: none and z-index: 9999 — safe to unclip. */
+.dockview-theme-light .dv-drop-target-container {
+  overflow: visible;
+}
+
 .dockview-theme-light .dv-drop-target-container .dv-drop-target-anchor {
   border: 2px solid var(--ws-drop-target-border);
   box-shadow: var(--ws-drop-target-shadow);

--- a/frontend/src/ui/layout/MainLayout.tsx
+++ b/frontend/src/ui/layout/MainLayout.tsx
@@ -14,6 +14,8 @@
 import { useCallback, useEffect, useRef, type FunctionComponent } from 'react';
 import {
   DockviewReact,
+  themeLight,
+  type DockviewTheme,
   type DockviewReadyEvent,
   type DockviewApi,
   type IDockviewPanelProps,
@@ -262,6 +264,12 @@ const COMPONENTS: Record<string, React.FunctionComponent<IDockviewPanelProps>> =
   'intake-workbench': IntakePanel,
   'artcollector-workbench': ArtCollectorPanel,
   'project-panel': ProjectPanel,
+};
+
+// Dockview v4 theme object — className stays 'dockview-theme-light' so all existing CSS selectors work
+const autoartTheme: DockviewTheme = {
+  ...themeLight,
+  name: 'autoart',
 };
 
 // ============================================================================
@@ -647,7 +655,7 @@ export function MainLayout() {
       {/* Main Dockview Area - fills remaining space */}
       <div className="flex-1 overflow-hidden h-full">
         <DockviewReact
-          className="dockview-theme-light"
+          theme={autoartTheme}
           onReady={onReady}
           components={COMPONENTS}
           tabComponents={tabComponents as Record<string, FunctionComponent<IDockviewPanelHeaderProps>>}


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #307**
  * **PR #308**
    * **PR #309** 👈
      * **PR #310**
        * **PR #311**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->

## Summary by Sourcery

Enhancements:
- Enable the drop-zone glow to extend beyond its container by removing overflow clipping on the drop-target container.


___

## **CodeAnt-AI Description**
Switch to Dockview v4 theme prop and restore drop-zone glow beyond its container

### What Changed
- Docking component now uses the v4 theme prop so the app's dock layout receives a proper theme object instead of relying on a className
- Drop target container no longer clips its shadow, allowing the drag-and-drop glow to be visible outside the container bounds
- Existing theme styles remain compatible so panel and tab visuals are unchanged

### Impact
`✅ Clearer drag-and-drop highlights`
`✅ Fewer clipped drop-shadow visuals`
`✅ Consistent docking theme application`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
