### PR TITLE
feat: add tab strip + button with contextual panel dropdown

### DIFF
--- a/frontend/src/styles/dockview-theme.css
+++ b/frontend/src/styles/dockview-theme.css
@@ -149,6 +149,33 @@
   background: var(--ws-tab-bg-hover);
 }
 
+/* === Tab strip add-panel button === */
+
+.dockview-theme-light .dv-right-actions-container .tab-strip-add-button {
+  display: flex;
+  align-items: center;
+  padding: 0 4px;
+}
+
+.dockview-theme-light .dv-right-actions-container .tab-strip-add-trigger {
+  color: var(--ws-muted-fg);
+  background: none;
+  border: none;
+  border-radius: 4px;
+  padding: 2px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color var(--ws-motion-duration-fast) var(--ws-motion-ease),
+              background-color var(--ws-motion-duration-fast) var(--ws-motion-ease);
+}
+
+.dockview-theme-light .dv-right-actions-container .tab-strip-add-trigger:hover {
+  color: var(--ws-fg);
+  background: var(--ws-tab-bg-hover);
+}
+
 /* === Panel content area === */
 
 .dockview-theme-light .dv-groupview > .dv-content-container {


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #307**
  * **PR #308**
    * **PR #309**
      * **PR #310**
        * **PR #311** 👈

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Add a tab-strip + button that opens a contextual panel dropdown for quick panel creation

### What Changed
- A new "+" button was added to the right side of the tab strip that opens a contextual dropdown to spawn panels.
- Dropdown is grouped into Tools, Registry, and Workbenches and includes options to open an Inspector split to the right or below the current panel.
- New spawn behavior creates uniquely named panels positioned relative to the active panel and respects panel size hints when placing them.
- Styling added for the tab-strip button and dropdown to match the existing dockview theme.

### Impact
`✅ Faster panel creation`
`✅ Easier opening of specific tools and workbenches`
`✅ Simpler workspace splitting (right or below)`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
