### PR TITLE
fix: normalize font-bold→semibold, enforce type scale

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -55,7 +55,7 @@ function App() {
     return (
       <div className="h-screen flex items-center justify-center bg-slate-100">
         <div className="text-center">
-          <div className="w-12 h-12 bg-slate-900 rounded-xl flex items-center justify-center text-white font-bold text-xl mx-auto mb-4 animate-pulse">
+          <div className="w-12 h-12 bg-slate-900 rounded-xl flex items-center justify-center text-white font-semibold text-xl mx-auto mb-4 animate-pulse">
             A
           </div>
           <p className="text-slate-500">Loading...</p>

--- a/frontend/src/intake/components/FormPage.tsx
+++ b/frontend/src/intake/components/FormPage.tsx
@@ -113,7 +113,7 @@ export function FormPage() {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <div className="text-center">
-          <h1 className="text-2xl font-bold text-slate-900 mb-2">Form Not Found</h1>
+          <h1 className="text-xl font-semibold text-slate-900 mb-2">Form Not Found</h1>
           <p className="text-slate-600">
             This form may have been disabled or doesn't exist.
           </p>
@@ -139,7 +139,7 @@ export function FormPage() {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
             </svg>
           </div>
-          <h1 className="text-2xl font-bold text-slate-900 mb-2">Submitted!</h1>
+          <h1 className="text-xl font-semibold text-slate-900 mb-2">Submitted!</h1>
           <p className="text-slate-600">{confirmationMessage}</p>
           {redirectUrl && (
             <p className="text-sm text-slate-400 mt-4">Redirecting...</p>
@@ -159,7 +159,7 @@ export function FormPage() {
     <div className="max-w-2xl mx-auto py-8 px-4">
       {/* Header */}
       <div className="mb-8">
-        <h1 className="text-2xl font-bold text-slate-900">{form.title}</h1>
+        <h1 className="text-xl font-semibold text-slate-900">{form.title}</h1>
         {form.sharepoint_request_url && (
           <a
             href={form.sharepoint_request_url}
@@ -191,7 +191,7 @@ export function FormPage() {
 
       {/* Page Title */}
       {(currentPageData?.blocks_config?.settings as any)?.pageTitle && (
-        <h2 className="text-lg font-semibold text-slate-800 mb-4">
+        <h2 className="text-base font-semibold text-slate-800 mb-4">
           {(currentPageData.blocks_config.settings as any).pageTitle}
         </h2>
       )}

--- a/frontend/src/intake/components/NotFoundPage.tsx
+++ b/frontend/src/intake/components/NotFoundPage.tsx
@@ -2,7 +2,7 @@ export function NotFoundPage() {
   return (
     <div className="flex items-center justify-center min-h-screen">
       <div className="text-center">
-        <h1 className="text-4xl font-bold text-slate-900 mb-2">404</h1>
+        <h1 className="text-2xl font-semibold text-slate-900 mb-2">404</h1>
         <p className="text-slate-600">Page not found</p>
       </div>
     </div>

--- a/frontend/src/intake/components/SuccessPage.tsx
+++ b/frontend/src/intake/components/SuccessPage.tsx
@@ -8,7 +8,7 @@ export function SuccessPage() {
     <div className="flex items-center justify-center min-h-screen">
       <div className="text-center max-w-md mx-auto px-4">
         <CheckCircle className="w-16 h-16 text-green-600 mx-auto mb-4" />
-        <h1 className="text-2xl font-bold text-slate-900 mb-2">
+        <h1 className="text-xl font-semibold text-slate-900 mb-2">
           Submission Complete
         </h1>
         <p className="text-slate-600 mb-6">

--- a/frontend/src/intake/components/blocks/SectionHeader.tsx
+++ b/frontend/src/intake/components/blocks/SectionHeader.tsx
@@ -7,7 +7,7 @@ interface SectionHeaderProps {
 export function SectionHeader({ block }: SectionHeaderProps) {
   return (
     <div className="pt-6 pb-2">
-      <h3 className="text-lg font-semibold text-slate-900">{block.label}</h3>
+      <h3 className="text-base font-semibold text-slate-900">{block.label}</h3>
       {block.description && (
         <p className="mt-1 text-sm text-slate-500">{block.description}</p>
       )}

--- a/frontend/src/pages/ActionsPage.tsx
+++ b/frontend/src/pages/ActionsPage.tsx
@@ -84,7 +84,7 @@ export function ActionsPage() {
                             {activeTab === 'definitions' ? (
                                 <div className="h-full flex items-center justify-center text-slate-400">
                                     <div className="text-center">
-                                        <p className="text-lg font-medium text-slate-600">Action Definitions</p>
+                                        <p className="text-sm text-slate-600">Action Definitions</p>
                                         <p>Select a definition from the sidebar to view its schema.</p>
                                         <p className="text-xs mt-2">Use the + button to create a new action definition in Composer.</p>
                                     </div>

--- a/frontend/src/pages/EventsPage.tsx
+++ b/frontend/src/pages/EventsPage.tsx
@@ -28,7 +28,7 @@ export function EventsPage() {
             <div className="flex flex-1 flex-col overflow-hidden">
                 {/* Page Header */}
                 <div className="h-12 border-b border-slate-200 bg-white flex items-center justify-between px-4">
-                    <h1 className="text-lg font-semibold text-slate-800 flex items-center gap-2">
+                    <h1 className="text-xl font-semibold text-slate-800 flex items-center gap-2">
                         <Activity size={20} className="text-emerald-500" />
                         Events
                     </h1>

--- a/frontend/src/pages/FieldsPage.tsx
+++ b/frontend/src/pages/FieldsPage.tsx
@@ -71,7 +71,7 @@ export function FieldsPage() {
                                 <div className="w-16 h-16 bg-slate-100 rounded-full flex items-center justify-center mx-auto mb-4">
                                     <ClipboardList size={32} className="text-slate-300" />
                                 </div>
-                                <p className="text-lg font-medium text-slate-600">No Field Selected</p>
+                                <p className="text-sm text-slate-600">No Field Selected</p>
                                 <p className="text-sm mt-1">Select a field from the Definitions tab first.</p>
                             </div>
                         </div>

--- a/frontend/src/pages/Intake/IntakeDashboard.tsx
+++ b/frontend/src/pages/Intake/IntakeDashboard.tsx
@@ -52,7 +52,7 @@ export function IntakeDashboard({ onOpenForm }: IntakeDashboardProps) {
             {/* Header */}
             <div className="flex items-center justify-between mb-8">
                 <div>
-                    <h1 className="text-2xl font-bold text-slate-800">Intake Forms</h1>
+                    <h1 className="text-xl font-semibold text-slate-800">Intake Forms</h1>
                     <p className="text-sm text-slate-500 mt-1">
                         Create and manage intake forms for collecting submissions
                     </p>

--- a/frontend/src/pages/Intake/IntakeEditorView.tsx
+++ b/frontend/src/pages/Intake/IntakeEditorView.tsx
@@ -268,7 +268,7 @@ export function IntakeEditorView({ formId, onBack }: IntakeEditorViewProps) {
                             type="text"
                             value={formTitle}
                             onChange={(e) => handleTitleChange(e.target.value)}
-                            className="text-sm font-bold text-slate-800 bg-transparent border-none p-0 focus:ring-0 w-48 hover:border-b hover:border-slate-300 focus:border-b focus:border-indigo-500"
+                            className="text-sm font-semibold text-slate-800 bg-transparent border-none p-0 focus:ring-0 w-48 hover:border-b hover:border-slate-300 focus:border-b focus:border-indigo-500"
                         />
                         {renderSaveStatus()}
                     </div>
@@ -336,7 +336,7 @@ export function IntakeEditorView({ formId, onBack }: IntakeEditorViewProps) {
                                     value={formTitle}
                                     onChange={(e) => handleTitleChange(e.target.value)}
                                     placeholder="Form Title"
-                                    className="w-full text-3xl font-bold text-slate-800 bg-transparent border-none p-0 focus:outline-none focus:ring-0"
+                                    className="w-full text-xl font-semibold text-slate-800 bg-transparent border-none p-0 focus:outline-none focus:ring-0"
                                 />
                                 <textarea
                                     value={formDescription}
@@ -368,7 +368,7 @@ export function IntakeEditorView({ formId, onBack }: IntakeEditorViewProps) {
                             <div className="w-16 h-16 rounded-full bg-slate-100 flex items-center justify-center mx-auto mb-4">
                                 <span className="text-2xl">🔀</span>
                             </div>
-                            <h3 className="text-lg font-semibold text-slate-700">Conditional Logic</h3>
+                            <h3 className="text-base font-semibold text-slate-700">Conditional Logic</h3>
                             <p className="text-sm text-slate-500 mt-2">
                                 Coming soon: Add conditional display rules to show or hide questions based on previous answers.
                             </p>
@@ -402,7 +402,7 @@ export function IntakeEditorView({ formId, onBack }: IntakeEditorViewProps) {
             {showPublishDialog && publicUrl && (
                 <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
                     <div className="bg-white rounded-xl p-6 max-w-md w-full mx-4 shadow-xl">
-                        <h2 className="text-xl font-bold text-slate-900 mb-2">
+                        <h2 className="text-base font-semibold text-slate-900 mb-2">
                             Form Published
                         </h2>
                         <p className="text-slate-600 mb-4">

--- a/frontend/src/pages/MailPage.tsx
+++ b/frontend/src/pages/MailPage.tsx
@@ -215,7 +215,7 @@ export function MailPage() {
         ) : isError ? (
           <div className="flex flex-col items-center justify-center h-64 text-center">
             <AlertCircle className="text-red-400 mb-3" size={40} />
-            <h3 className="text-lg font-medium text-slate-900 mb-1">Failed to load emails</h3>
+            <h3 className="text-sm text-slate-900 mb-1">Failed to load emails</h3>
             <p className="text-sm text-slate-500 mb-4">
               {error instanceof Error ? error.message : 'Could not connect to AutoHelper'}
             </p>
@@ -229,7 +229,7 @@ export function MailPage() {
         ) : data?.emails.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-64 text-center">
             <Mail className="text-slate-300 mb-3" size={40} />
-            <h3 className="text-lg font-medium text-slate-900 mb-1">No emails yet</h3>
+            <h3 className="text-sm text-slate-900 mb-1">No emails yet</h3>
             <p className="text-sm text-slate-500">Emails will appear here once ingested</p>
           </div>
         ) : (

--- a/frontend/src/pages/RecordsPage.tsx
+++ b/frontend/src/pages/RecordsPage.tsx
@@ -88,7 +88,7 @@ export function RecordsPage() {
               {activeTab === 'definitions' ? (
                 <div className="h-full flex items-center justify-center text-slate-400">
                   <div className="text-center">
-                    <p className="text-lg font-medium text-slate-600">Record Definitions</p>
+                    <p className="text-sm text-slate-600">Record Definitions</p>
                     <p>Select a definition from the sidebar to view its schema.</p>
                   </div>
                 </div>

--- a/frontend/src/pages/settings/AccountSection.tsx
+++ b/frontend/src/pages/settings/AccountSection.tsx
@@ -53,7 +53,7 @@ export function AccountSection() {
     return (
         <div className="space-y-6">
             <div>
-                <h2 className="text-lg font-semibold text-slate-900">Account</h2>
+                <h2 className="text-base font-semibold text-slate-900">Account</h2>
                 <p className="text-sm text-slate-500 mt-1">
                     Your profile and account settings
                 </p>

--- a/frontend/src/pages/settings/AppearanceSection.tsx
+++ b/frontend/src/pages/settings/AppearanceSection.tsx
@@ -46,7 +46,7 @@ export function AppearanceSection() {
   return (
     <div className="space-y-6">
       <div>
-        <h2 className="text-lg font-semibold text-slate-900">Appearance</h2>
+        <h2 className="text-base font-semibold text-slate-900">Appearance</h2>
         <p className="text-sm text-slate-500 mt-1">
           Customize the look and feel of your workspace
         </p>

--- a/frontend/src/pages/settings/AutoHelperSection.tsx
+++ b/frontend/src/pages/settings/AutoHelperSection.tsx
@@ -206,7 +206,7 @@ function PairingCodeCard({
                             <p className="text-xs text-slate-500 mb-2">
                                 Enter this code in AutoHelper:
                             </p>
-                            <div className="font-mono text-3xl font-bold text-slate-900 tracking-widest">
+                            <div className="font-mono text-xl font-semibold text-slate-900 tracking-widest">
                                 {pairingCode}
                             </div>
                             {expiresAt && (
@@ -674,7 +674,7 @@ export function AutoHelperSection({
         return (
             <div className="space-y-6">
                 <div>
-                    <h2 className="text-lg font-semibold text-slate-900">AutoHelper</h2>
+                    <h2 className="text-base font-semibold text-slate-900">AutoHelper</h2>
                     <p className="text-sm text-slate-500 mt-1">Local service management</p>
                 </div>
                 {pairingCard}
@@ -690,7 +690,7 @@ export function AutoHelperSection({
         return (
             <div className="space-y-6">
                 <div>
-                    <h2 className="text-lg font-semibold text-slate-900">AutoHelper</h2>
+                    <h2 className="text-base font-semibold text-slate-900">AutoHelper</h2>
                     <p className="text-sm text-slate-500 mt-1">Local service management</p>
                 </div>
                 {pairingCard}
@@ -710,7 +710,7 @@ export function AutoHelperSection({
     return (
         <div className="space-y-6">
             <div>
-                <h2 className="text-lg font-semibold text-slate-900">AutoHelper</h2>
+                <h2 className="text-base font-semibold text-slate-900">AutoHelper</h2>
                 <p className="text-sm text-slate-500 mt-1">Local service management</p>
             </div>
 

--- a/frontend/src/pages/settings/IntegrationsSection.tsx
+++ b/frontend/src/pages/settings/IntegrationsSection.tsx
@@ -583,7 +583,7 @@ export function IntegrationsSection({
     return (
         <div className="space-y-6">
             <div>
-                <h2 className="text-lg font-semibold text-slate-900">Integrations</h2>
+                <h2 className="text-base font-semibold text-slate-900">Integrations</h2>
                 <p className="text-sm text-slate-500 mt-1">
                     Connect external services to import data and enable sync
                 </p>

--- a/frontend/src/ui/atoms/AssigneeChipGroup.tsx
+++ b/frontend/src/ui/atoms/AssigneeChipGroup.tsx
@@ -122,7 +122,7 @@ export function AssigneeChipGroup({
                             ${SIZE_CLASSES[size]}
                             ${getColorForName(a.name)}
                             ${index > 0 ? OVERLAP_CLASSES[size] : ''}
-                            rounded-full flex items-center justify-center font-bold
+                            rounded-full flex items-center justify-center font-semibold
                             border-2 border-white shadow-sm
                         `}
                     >

--- a/frontend/src/ui/composer/ComposerView.tsx
+++ b/frontend/src/ui/composer/ComposerView.tsx
@@ -340,7 +340,7 @@ export function ComposerView({
                             <Wand2 size={20} />
                         </div>
                         <div>
-                            <h1 className="text-lg font-semibold text-slate-900">Composer</h1>
+                            <h1 className="text-xl font-semibold text-slate-900">Composer</h1>
                             <p className="text-xs text-slate-500">Declare intent with Actions + Events</p>
                         </div>
                     </div>

--- a/frontend/src/ui/composites/ActionCard.tsx
+++ b/frontend/src/ui/composites/ActionCard.tsx
@@ -128,7 +128,7 @@ export function ActionCard({
                             size={14}
                             className={`text-slate-400 transition-transform ${!isExpanded ? '-rotate-90' : ''}`}
                         />
-                        <span className="bg-indigo-100 text-indigo-700 border border-indigo-200 text-[10px] font-bold px-1.5 py-0.5 rounded">
+                        <span className="bg-indigo-100 text-indigo-700 border border-indigo-200 text-[10px] font-semibold px-1.5 py-0.5 rounded">
                             ACTION: {action.type}
                         </span>
                         <span className="text-sm font-medium text-slate-700 truncate max-w-[200px]">
@@ -145,7 +145,7 @@ export function ActionCard({
                     <>
                         {/* Field Bindings */}
                         <div className="pl-6 mb-4">
-                            <div className="text-[10px] font-bold text-slate-400 uppercase mb-1.5 tracking-wider">
+                            <div className="text-[10px] font-semibold text-slate-400 uppercase mb-1.5 tracking-wider">
                                 Field Bindings
                             </div>
                             {displayBindings.length > 0 ? (
@@ -170,7 +170,7 @@ export function ActionCard({
                                         e.stopPropagation();
                                         onRetract();
                                     }}
-                                    className="text-[10px] font-bold text-red-600 bg-red-50 hover:bg-red-100 border border-red-100 px-3 py-1.5 rounded transition-colors flex items-center gap-1"
+                                    className="text-[10px] font-semibold text-red-600 bg-red-50 hover:bg-red-100 border border-red-100 px-3 py-1.5 rounded transition-colors flex items-center gap-1"
                                 >
                                     <XCircle size={12} /> Retract
                                 </button>
@@ -181,7 +181,7 @@ export function ActionCard({
                                         e.stopPropagation();
                                         onAmend();
                                     }}
-                                    className="text-[10px] font-bold text-slate-600 bg-white hover:bg-slate-50 border border-slate-200 px-3 py-1.5 rounded transition-colors flex items-center gap-1"
+                                    className="text-[10px] font-semibold text-slate-600 bg-white hover:bg-slate-50 border border-slate-200 px-3 py-1.5 rounded transition-colors flex items-center gap-1"
                                 >
                                     <PencilLine size={12} /> Amend
                                 </button>
@@ -207,7 +207,7 @@ export function ActionCard({
                         size={12}
                         className={`transition-transform ${!eventsExpanded ? '-rotate-90' : ''}`}
                     />
-                    <span className="text-[10px] font-bold uppercase tracking-wider">
+                    <span className="text-[10px] font-semibold uppercase tracking-wider">
                         Events emitted ({visibleEvents.length})
                     </span>
                 </div>

--- a/frontend/src/ui/composites/ActionsList.tsx
+++ b/frontend/src/ui/composites/ActionsList.tsx
@@ -98,7 +98,7 @@ export function ActionsList({
         return (
             <div className={clsx('flex flex-col items-center justify-center h-64 text-slate-400', className)}>
                 <Zap size={40} className="mb-3 text-slate-200" />
-                <p className="text-lg font-medium">No actions yet</p>
+                <p className="text-sm">No actions yet</p>
                 <p className="text-sm">Actions will appear here once declared</p>
             </div>
         );

--- a/frontend/src/ui/composites/ActionsTableFlat.tsx
+++ b/frontend/src/ui/composites/ActionsTableFlat.tsx
@@ -345,7 +345,7 @@ export function ActionsTableFlat({
         return (
             <div className={clsx('flex flex-col items-center justify-center h-64 text-slate-400', className)}>
                 <Zap size={32} className="mb-2 text-slate-300" />
-                <p className="text-lg font-medium">Select an action type</p>
+                <p className="text-sm">Select an action type</p>
                 <p className="text-sm">Choose an action type from the sidebar to view instances</p>
             </div>
         );
@@ -356,7 +356,7 @@ export function ActionsTableFlat({
         return (
             <div className={clsx('flex flex-col items-center justify-center h-64 text-slate-400', className)}>
                 <Zap size={32} className="mb-2 text-purple-200" />
-                <p className="text-lg font-medium">{emptyMessage}</p>
+                <p className="text-sm">{emptyMessage}</p>
                 <p className="text-sm mb-4">Create your first {definition?.name || 'action'} using the Composer</p>
                 {onAddAction && (
                     <button

--- a/frontend/src/ui/composites/DataTableFlat.tsx
+++ b/frontend/src/ui/composites/DataTableFlat.tsx
@@ -136,7 +136,7 @@ function ColumnPicker({ allColumns, visibleKeys, onToggle }: ColumnPickerProps) 
                 <>
                     <div className="fixed inset-0 z-10" onClick={() => setIsOpen(false)} />
                     <div className="absolute top-full right-0 mt-1 w-48 bg-white border border-slate-200 rounded-lg shadow-lg z-20 py-1 max-h-64 overflow-y-auto">
-                        <div className="px-3 py-1.5 text-[10px] font-bold text-slate-400 uppercase">
+                        <div className="px-3 py-1.5 text-[10px] font-semibold text-slate-400 uppercase">
                             Visible Columns
                         </div>
                         {allColumns.map((col) => (
@@ -658,7 +658,7 @@ export function DataTableFlat({
     if (!definition) {
         return (
             <div className={clsx('flex flex-col items-center justify-center h-64 text-slate-400', className)}>
-                <p className="text-lg font-medium">No definition</p>
+                <p className="text-sm">No definition</p>
                 <p className="text-sm">Select a record type to view</p>
             </div>
         );
@@ -668,7 +668,7 @@ export function DataTableFlat({
     if (records.length === 0) {
         return (
             <div className={clsx('flex flex-col items-center justify-center h-64 text-slate-400', className)}>
-                <p className="text-lg font-medium">{emptyMessage}</p>
+                <p className="text-sm">{emptyMessage}</p>
             </div>
         );
     }

--- a/frontend/src/ui/composites/DataTableImport.tsx
+++ b/frontend/src/ui/composites/DataTableImport.tsx
@@ -223,7 +223,7 @@ function ClassificationBadge({ classification }: { classification: ItemClassific
 
     return (
         <span
-            className={`inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-bold uppercase rounded ${styles.bg} ${styles.text}`}
+            className={`inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-semibold uppercase rounded ${styles.bg} ${styles.text}`}
             title={classification.rationale}
         >
             {needsAttention && <AlertCircle className="w-3 h-3" />}
@@ -235,7 +235,7 @@ function ClassificationBadge({ classification }: { classification: ItemClassific
 
 function EntityTypeBadge({ entityType }: { entityType: string }) {
     return (
-        <span className="text-[10px] font-bold uppercase text-slate-400 bg-slate-100 px-1.5 py-0.5 rounded">
+        <span className="text-[10px] font-semibold uppercase text-slate-400 bg-slate-100 px-1.5 py-0.5 rounded">
             {entityType}
         </span>
     );
@@ -540,7 +540,7 @@ function NestedLevel({
     return (
         <div className={clsx('border border-slate-200 rounded-lg overflow-hidden', depth > 0 && 'ml-6 mt-2 mb-2')}>
             {/* Header row for this level */}
-            <div className="flex bg-slate-100 text-[10px] font-bold uppercase text-slate-500 border-b border-slate-200">
+            <div className="flex bg-slate-100 text-[10px] font-semibold uppercase text-slate-500 border-b border-slate-200">
                 <div className="flex-1 min-w-[200px] px-3 py-1.5">Title</div>
                 <div className="w-16 px-2 py-1.5 text-center">Type</div>
                 {levelFields.map(field => (

--- a/frontend/src/ui/composites/FinanceKPIStrip.tsx
+++ b/frontend/src/ui/composites/FinanceKPIStrip.tsx
@@ -85,7 +85,7 @@ export function FinanceKPIStrip() {
           <div className="text-[10px] font-medium text-slate-400 uppercase tracking-wide">
             {kpi.label}
           </div>
-          <div className="text-lg font-mono font-semibold text-slate-800 mt-0.5">
+          <div className="text-base font-mono font-semibold text-slate-800 mt-0.5">
             {kpi.value}
           </div>
           {kpi.sublabel && (

--- a/frontend/src/ui/composites/ImportItemDetailsView.tsx
+++ b/frontend/src/ui/composites/ImportItemDetailsView.tsx
@@ -219,7 +219,7 @@ export function ImportItemDetailsView({ itemId, tab, plan: propPlan }: ImportIte
                                         <Text size="xs" color="muted" className="uppercase tracking-wide mb-1">Outcome</Text>
                                         <Badge
                                             size="sm"
-                                            className={`${OUTCOME_COLORS[classification.outcome]?.bg || 'bg-slate-100'} ${OUTCOME_COLORS[classification.outcome]?.text || 'text-slate-600'} font-bold`}
+                                            className={`${OUTCOME_COLORS[classification.outcome]?.bg || 'bg-slate-100'} ${OUTCOME_COLORS[classification.outcome]?.text || 'text-slate-600'} font-semibold`}
                                         >
                                             {classification.outcome.replace(/_/g, ' ')}
                                         </Badge>
@@ -359,7 +359,7 @@ export function ImportItemDetailsView({ itemId, tab, plan: propPlan }: ImportIte
                         {selectedItem.title}
                     </Text>
                     <div className="mt-3 flex items-center gap-2">
-                        <Badge variant="neutral" size="sm" className="uppercase text-[10px] font-bold">
+                        <Badge variant="neutral" size="sm" className="uppercase text-[10px] font-semibold">
                             {isContainer
                                 ? (selectedItem as { type?: string }).type || 'container'
                                 : (selectedItem as { entityType?: string }).entityType || 'item'}

--- a/frontend/src/ui/composites/IngestionView.tsx
+++ b/frontend/src/ui/composites/IngestionView.tsx
@@ -122,7 +122,7 @@ export function IngestionView({ onImportComplete }: IngestionViewProps) {
             {/* Left Panel: Configuration */}
             <div className="w-96 border-r border-slate-200 flex flex-col bg-white shrink-0">
                 <div className="h-12 border-b border-slate-100 flex items-center px-4 bg-slate-50">
-                    <h2 className="text-xs font-bold text-slate-500 uppercase tracking-wide">
+                    <h2 className="text-xs font-semibold text-slate-500 uppercase tracking-wide">
                         Input & Logic
                     </h2>
                 </div>
@@ -130,7 +130,7 @@ export function IngestionView({ onImportComplete }: IngestionViewProps) {
                 <div className="flex-1 overflow-y-auto custom-scroll">
                     {/* Section 1: Data Source */}
                     <div className="p-5 border-b border-slate-200">
-                        <label className="text-xs font-bold text-slate-800 uppercase mb-3 flex justify-between">
+                        <label className="text-xs font-semibold text-slate-800 uppercase mb-3 flex justify-between">
                             <span>1. Data Source</span>
                             <span className="text-[10px] font-normal text-slate-400 lowercase">csv, xlsx, json</span>
                         </label>
@@ -157,7 +157,7 @@ export function IngestionView({ onImportComplete }: IngestionViewProps) {
                         {/* Paste Area */}
                         <div className="flex items-center gap-2 mb-2">
                             <span className="h-px bg-slate-200 flex-1" />
-                            <span className="text-[10px] text-slate-400 font-bold uppercase">OR PASTE RAW DATA</span>
+                            <span className="text-[10px] text-slate-400 font-semibold uppercase">OR PASTE RAW DATA</span>
                             <span className="h-px bg-slate-200 flex-1" />
                         </div>
 
@@ -172,7 +172,7 @@ export function IngestionView({ onImportComplete }: IngestionViewProps) {
                     {/* Section 2: Parser Modules */}
                     <div className="p-5 bg-slate-50/50 flex-1">
                         <div className="flex justify-between items-center mb-3">
-                            <label className="text-xs font-bold text-slate-800 uppercase">
+                            <label className="text-xs font-semibold text-slate-800 uppercase">
                                 2. Parser Module
                             </label>
                             <span className="text-[10px] text-slate-400">Logic for interpretation</span>
@@ -190,14 +190,14 @@ export function IngestionView({ onImportComplete }: IngestionViewProps) {
                                 >
                                     <div className="flex justify-between items-start mb-2">
                                         <div className="flex items-center gap-3">
-                                            <div className={`w-8 h-8 rounded flex items-center justify-center text-sm font-bold ${parser.name === 'monday'
+                                            <div className={`w-8 h-8 rounded flex items-center justify-center text-sm font-semibold ${parser.name === 'monday'
                                                     ? 'bg-indigo-100 text-indigo-600 border border-indigo-200'
                                                     : 'bg-yellow-100 text-yellow-600 border border-yellow-200'
                                                 }`}>
                                                 {parser.name.charAt(0).toUpperCase()}
                                             </div>
                                             <div>
-                                                <div className={`text-sm font-bold ${selectedParser === parser.name ? 'text-blue-900' : 'text-slate-700'}`}>
+                                                <div className={`text-sm font-semibold ${selectedParser === parser.name ? 'text-blue-900' : 'text-slate-700'}`}>
                                                     {parser.name === 'monday' ? 'Monday.com v2' : 'Airtable Grid'}
                                                 </div>
                                                 <div className={`text-[10px] ${selectedParser === parser.name ? 'text-blue-600' : 'text-slate-400'}`}>
@@ -215,7 +215,7 @@ export function IngestionView({ onImportComplete }: IngestionViewProps) {
                                         <div className="mt-3 pt-3 border-t border-blue-200/60 space-y-3">
                                             {parser.configFields.map((field) => (
                                                 <div key={field.key}>
-                                                    <label className="text-[10px] text-blue-500 font-bold block mb-1">
+                                                    <label className="text-[10px] text-blue-500 font-semibold block mb-1">
                                                         {field.label}
                                                     </label>
                                                     <input
@@ -242,15 +242,15 @@ export function IngestionView({ onImportComplete }: IngestionViewProps) {
             <div className="flex-1 flex flex-col bg-slate-50">
                 {/* Preview Header */}
                 <div className="h-10 bg-white border-b border-slate-200 flex items-center justify-between px-4 shrink-0 shadow-sm">
-                    <span className="text-xs font-bold text-slate-500 uppercase">Live Output Preview</span>
+                    <span className="text-xs font-semibold text-slate-500 uppercase">Live Output Preview</span>
                     <div className="flex gap-3">
                         {preview.data && (
                             <>
                                 <span className="text-[10px] text-slate-500">
-                                    <span className="font-bold text-slate-800">{preview.data.stageCount}</span> Stages
+                                    <span className="font-semibold text-slate-800">{preview.data.stageCount}</span> Stages
                                 </span>
                                 <span className="text-[10px] text-slate-500">
-                                    <span className="font-bold text-slate-800">{preview.data.taskCount}</span> Tasks
+                                    <span className="font-semibold text-slate-800">{preview.data.taskCount}</span> Tasks
                                 </span>
                             </>
                         )}
@@ -278,18 +278,18 @@ export function IngestionView({ onImportComplete }: IngestionViewProps) {
                             <div className="bg-white border border-purple-200 rounded-lg p-4 shadow-sm relative overflow-hidden">
                                 <div className="absolute top-0 left-0 w-1 h-full bg-purple-500" />
                                 <div className="flex items-start gap-3">
-                                    <span className="text-[10px] font-bold text-purple-600 uppercase bg-purple-50 px-2 py-1 rounded border border-purple-100">
+                                    <span className="text-[10px] font-semibold text-purple-600 uppercase bg-purple-50 px-2 py-1 rounded border border-purple-100">
                                         Project Record
                                     </span>
                                 </div>
-                                <h2 className="text-lg font-bold text-slate-800 mt-2">
+                                <h2 className="text-base font-semibold text-slate-800 mt-2">
                                     {preview.data.parsedData.projectTitle}
                                 </h2>
                                 {Object.keys(preview.data.parsedData.projectMeta).length > 0 && (
                                     <div className="flex gap-6 mt-2 text-sm">
                                         {Object.entries(preview.data.parsedData.projectMeta).map(([key, value]) => (
                                             <div key={key}>
-                                                <span className="text-[10px] font-bold text-slate-400 uppercase">{key}</span>
+                                                <span className="text-[10px] font-semibold text-slate-400 uppercase">{key}</span>
                                                 <div className="font-medium text-slate-700">{String(value)}</div>
                                             </div>
                                         ))}
@@ -309,7 +309,7 @@ export function IngestionView({ onImportComplete }: IngestionViewProps) {
                                     style={{ marginLeft: getNodeIndent(node.type) }}
                                 >
                                     <div className="flex items-center gap-2">
-                                        <span className={`text-[10px] font-bold uppercase px-1.5 py-0.5 rounded ${node.type === 'process' ? 'bg-purple-100 text-purple-600' :
+                                        <span className={`text-[10px] font-semibold uppercase px-1.5 py-0.5 rounded ${node.type === 'process' ? 'bg-purple-100 text-purple-600' :
                                                 node.type === 'stage' ? 'bg-yellow-100 text-yellow-600' :
                                                     node.type === 'subprocess' ? 'bg-orange-100 text-orange-600' :
                                                         'bg-blue-100 text-blue-600'

--- a/frontend/src/ui/composites/ProjectLogView.tsx
+++ b/frontend/src/ui/composites/ProjectLogView.tsx
@@ -85,7 +85,7 @@ export function ProjectLogView({ projectId: _projectId }: ProjectLogViewProps) {
           />
           <button
             onClick={handleDeclareAction}
-            className="bg-slate-900 text-white px-4 py-1.5 rounded-lg text-xs font-bold hover:bg-slate-800 transition-colors mr-1"
+            className="bg-slate-900 text-white px-4 py-1.5 rounded-lg text-xs font-semibold hover:bg-slate-800 transition-colors mr-1"
           >
             Declare
           </button>
@@ -142,7 +142,7 @@ function ActionCardItem({ card }: { card: ActionCard }) {
         {/* Header */}
         <div className="px-5 py-4 border-b border-slate-100 bg-slate-50/50 flex justify-between items-start">
           <div className="flex-1">
-            <h3 className="text-base font-bold text-slate-800">{card.title}</h3>
+            <h3 className="text-base font-semibold text-slate-800">{card.title}</h3>
             <div className="flex items-center gap-2 mt-1 text-xs text-slate-500">
               {card.refCode && (
                 <>
@@ -251,13 +251,13 @@ function ActionBar({ status, actionId }: { status: string; actionId: number }) {
         <>
           <button
             onClick={() => handleTransition('complete')}
-            className="flex items-center gap-2 bg-white border border-slate-200 hover:border-emerald-300 hover:text-emerald-700 text-slate-600 px-3 py-1.5 rounded text-xs font-bold transition-all shadow-sm"
+            className="flex items-center gap-2 bg-white border border-slate-200 hover:border-emerald-300 hover:text-emerald-700 text-slate-600 px-3 py-1.5 rounded text-xs font-semibold transition-all shadow-sm"
           >
             <CheckCircle size={16} /> Complete
           </button>
           <button
             onClick={() => handleTransition('block')}
-            className="flex items-center gap-2 bg-white border border-slate-200 hover:border-red-300 hover:text-red-700 text-slate-600 px-3 py-1.5 rounded text-xs font-bold transition-all shadow-sm"
+            className="flex items-center gap-2 bg-white border border-slate-200 hover:border-red-300 hover:text-red-700 text-slate-600 px-3 py-1.5 rounded text-xs font-semibold transition-all shadow-sm"
           >
             <HandPalm size={16} /> Block
           </button>
@@ -266,7 +266,7 @@ function ActionBar({ status, actionId }: { status: string; actionId: number }) {
       {status === 'declared' && (
         <button
           onClick={() => handleTransition('start')}
-          className="flex items-center gap-2 bg-white border border-slate-200 hover:border-indigo-300 hover:text-indigo-700 text-slate-600 px-3 py-1.5 rounded text-xs font-bold transition-all shadow-sm"
+          className="flex items-center gap-2 bg-white border border-slate-200 hover:border-indigo-300 hover:text-indigo-700 text-slate-600 px-3 py-1.5 rounded text-xs font-semibold transition-all shadow-sm"
         >
           <Play size={16} /> Start
         </button>
@@ -314,9 +314,9 @@ function getEventColorClass(type: EventType) {
 
 function getEventTextClass(type: EventType) {
   switch (type) {
-    case 'work_started': return 'text-indigo-700 font-bold';
-    case 'work_finished': return 'text-emerald-700 font-bold';
-    case 'blocked': return 'text-red-700 font-bold';
+    case 'work_started': return 'text-indigo-700 font-semibold';
+    case 'work_finished': return 'text-emerald-700 font-semibold';
+    case 'blocked': return 'text-red-700 font-semibold';
     case 'unblocked': return 'text-emerald-700 font-medium';
     case 'field_value_recorded': return 'text-slate-700 font-medium';
     default: return 'text-slate-700 font-medium';

--- a/frontend/src/ui/composites/ProjectView.tsx
+++ b/frontend/src/ui/composites/ProjectView.tsx
@@ -190,7 +190,7 @@ export function ProjectView({ projectId, className }: ProjectViewProps) {
         return (
             <div className="flex-1 flex items-center justify-center bg-slate-50 text-slate-400">
                 <div className="text-center">
-                    <p className="text-lg font-medium">No project selected</p>
+                    <p className="text-sm">No project selected</p>
                     <p className="text-sm">Select a project from the top menu</p>
                 </div>
             </div>
@@ -201,7 +201,7 @@ export function ProjectView({ projectId, className }: ProjectViewProps) {
         return (
             <div className="flex-1 flex items-center justify-center bg-slate-50 text-slate-400">
                 <div className="text-center">
-                    <p className="text-lg font-medium">Loading project…</p>
+                    <p className="text-sm">Loading project…</p>
                 </div>
             </div>
         );
@@ -416,7 +416,7 @@ export function ProjectView({ projectId, className }: ProjectViewProps) {
                     ) : (
                         <div className="flex-1 flex items-center justify-center text-slate-400">
                             <div className="text-center">
-                                <p className="text-lg font-medium">No scheduled actions</p>
+                                <p className="text-sm">No scheduled actions</p>
                                 <p className="text-sm mt-1">Add dates to actions to see them on the calendar</p>
                             </div>
                         </div>

--- a/frontend/src/ui/composites/RecordPropertiesView.tsx
+++ b/frontend/src/ui/composites/RecordPropertiesView.tsx
@@ -157,10 +157,10 @@ export function RecordPropertiesView({ itemId, isNode }: RecordPropertiesViewPro
             <div className={`${bgColor} border rounded-lg p-4`}>
                 <div className="flex items-start justify-between">
                     <div>
-                        <div className="text-[10px] opacity-75 font-bold uppercase mb-1">
+                        <div className="text-[10px] opacity-75 font-semibold uppercase mb-1">
                             Record Class: {nodeType}
                         </div>
-                        <div className="text-lg font-bold text-slate-900">{title}</div>
+                        <div className="text-base font-semibold text-slate-900">{title}</div>
                         <div className="text-xs opacity-50 mt-1 font-mono">
                             UUID: {item.id.slice(0, 11)}
                         </div>
@@ -177,7 +177,7 @@ export function RecordPropertiesView({ itemId, isNode }: RecordPropertiesViewPro
                                 </button>
                                 {showHistory && (
                                     <div className="absolute top-full right-0 mt-2 w-64 bg-white border border-slate-200 rounded-lg shadow-xl z-10 overflow-hidden">
-                                        <div className="px-3 py-2 bg-slate-50 border-b border-slate-100 text-xs font-bold text-slate-500">
+                                        <div className="px-3 py-2 bg-slate-50 border-b border-slate-100 text-xs font-semibold text-slate-500">
                                             Naming History
                                         </div>
                                         <div className="max-h-60 overflow-y-auto py-1">
@@ -218,7 +218,7 @@ export function RecordPropertiesView({ itemId, isNode }: RecordPropertiesViewPro
             {/* Description Editor (Only for Nodes) */}
             {isNode && (
                 <div className="space-y-2">
-                    <h4 className="text-xs font-bold text-slate-400 uppercase border-b border-slate-100 pb-2">
+                    <h4 className="text-xs font-semibold text-slate-400 uppercase border-b border-slate-100 pb-2">
                         Description
                     </h4>
                     <div className="border border-slate-200 rounded-md bg-white p-1 focus-within:ring-2 focus-within:ring-blue-500 focus-within:border-transparent transition-all">
@@ -235,7 +235,7 @@ export function RecordPropertiesView({ itemId, isNode }: RecordPropertiesViewPro
 
             {/* Fields Section */}
             <div className="space-y-4">
-                <h4 className="text-xs font-bold text-slate-400 uppercase border-b border-slate-100 pb-2">
+                <h4 className="text-xs font-semibold text-slate-400 uppercase border-b border-slate-100 pb-2">
                     Record Fields
                 </h4>
 

--- a/frontend/src/ui/composites/RecordView.tsx
+++ b/frontend/src/ui/composites/RecordView.tsx
@@ -391,7 +391,7 @@ export function RecordView({
                         <div className="w-16 h-16 bg-white rounded-2xl shadow-sm border border-slate-100 flex items-center justify-center mb-4">
                             <FolderOpen size={32} className="text-blue-500/50" />
                         </div>
-                        <h3 className="text-lg font-semibold text-slate-700 mb-1">Select a Record Type</h3>
+                        <h3 className="text-base font-semibold text-slate-700 mb-1">Select a Record Type</h3>
                         <p className="text-sm text-slate-500 max-w-xs text-center">
                             Choose a definition from the dropdown above to view and manage its records.
                         </p>

--- a/frontend/src/ui/editor/MentionChip.tsx
+++ b/frontend/src/ui/editor/MentionChip.tsx
@@ -284,7 +284,7 @@ export function MentionChip({ node, updateAttributes, editor, getPos }: NodeView
           <span className="absolute inset-0" />
         </PopoverTrigger>
         <PopoverContent className="min-w-[200px] p-0" align="start" sideOffset={8}>
-          <div className="px-3 py-1.5 text-[10px] text-slate-400 uppercase font-bold border-b border-slate-100">
+          <div className="px-3 py-1.5 text-[10px] text-slate-400 uppercase font-semibold border-b border-slate-100">
             Reference Actions
           </div>
 

--- a/frontend/src/ui/editor/MentionSuggestion.tsx
+++ b/frontend/src/ui/editor/MentionSuggestion.tsx
@@ -170,7 +170,7 @@ export const MentionSuggestion = forwardRef<MentionSuggestionRef, MentionSuggest
       return (
         <div className="mention-dropdown">
           <div className="px-3 py-2 bg-slate-50 border-b border-slate-100 flex items-center gap-2">
-            <span className={clsx('text-sm font-bold', triggerColor)}>{triggerChar}</span>
+            <span className={clsx('text-sm font-semibold', triggerColor)}>{triggerChar}</span>
             <span className="text-xs text-slate-400">{triggerLabel}</span>
           </div>
           <div className="p-4 text-center text-slate-400 text-sm">
@@ -185,7 +185,7 @@ export const MentionSuggestion = forwardRef<MentionSuggestionRef, MentionSuggest
       return (
         <div className="mention-dropdown">
           <div className="px-3 py-2 bg-slate-50 border-b border-slate-100 flex items-center gap-2">
-            <span className={clsx('text-sm font-bold', triggerColor)}>{triggerChar}</span>
+            <span className={clsx('text-sm font-semibold', triggerColor)}>{triggerChar}</span>
             <span className="text-xs text-slate-400">
               {query ? `Search: "${query}"` : triggerLabel}
             </span>
@@ -239,7 +239,7 @@ export const MentionSuggestion = forwardRef<MentionSuggestionRef, MentionSuggest
     return (
       <div className="mention-dropdown">
         <div className="px-3 py-2 bg-slate-50 border-b border-slate-100 flex items-center gap-2">
-          <span className={clsx('text-sm font-bold', triggerColor)}>{triggerChar}</span>
+          <span className={clsx('text-sm font-semibold', triggerColor)}>{triggerChar}</span>
           <span className="text-xs text-slate-400">
             {query ? `Search: "${query}"` : triggerLabel}
           </span>
@@ -257,7 +257,7 @@ export const MentionSuggestion = forwardRef<MentionSuggestionRef, MentionSuggest
           >
             <div className="flex items-center gap-2 flex-1 min-w-0">
               <span
-                className={clsx('text-[10px] font-bold uppercase px-1 py-0.5 rounded shrink-0', {
+                className={clsx('text-[10px] font-semibold uppercase px-1 py-0.5 rounded shrink-0', {
                   'bg-blue-100 text-blue-700': item.type === 'record',
                   'bg-purple-100 text-purple-700': item.type === 'node',
                 })}

--- a/frontend/src/ui/editor/RecordSearchCombobox.tsx
+++ b/frontend/src/ui/editor/RecordSearchCombobox.tsx
@@ -128,7 +128,7 @@ export function RecordSearchCombobox({
             >
                 <span
                     className={clsx(
-                        'text-[10px] font-bold uppercase px-1.5 py-0.5 rounded shrink-0',
+                        'text-[10px] font-semibold uppercase px-1.5 py-0.5 rounded shrink-0',
                         {
                             'bg-blue-100 text-blue-700': result.type === 'record',
                             'bg-purple-100 text-purple-700': result.type === 'node',
@@ -184,7 +184,7 @@ export function RecordSearchCombobox({
             : 'text-blue-600 bg-blue-50';
 
     const headerPrefix = (
-        <span className={clsx('text-xs font-bold px-1.5 py-0.5 rounded', triggerColor)}>
+        <span className={clsx('text-xs font-semibold px-1.5 py-0.5 rounded', triggerColor)}>
             {triggerChar}
         </span>
     );

--- a/frontend/src/ui/inspector/ActionDetailsPanel.tsx
+++ b/frontend/src/ui/inspector/ActionDetailsPanel.tsx
@@ -52,7 +52,7 @@ export function ActionDetailsPanel({ actionId }: ActionDetailsPanelProps) {
 
             {/* Action Info */}
             <section>
-                <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3">
+                <h3 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">
                     Action Info
                 </h3>
                 <dl className="space-y-2 text-sm">
@@ -79,7 +79,7 @@ export function ActionDetailsPanel({ actionId }: ActionDetailsPanelProps) {
 
             {/* Field Bindings */}
             <section>
-                <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3">
+                <h3 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">
                     Field Bindings
                 </h3>
                 {action.fieldBindings && action.fieldBindings.length > 0 ? (

--- a/frontend/src/ui/inspector/ActionEventsPanel.tsx
+++ b/frontend/src/ui/inspector/ActionEventsPanel.tsx
@@ -36,7 +36,7 @@ export function ActionEventsPanel({ actionId }: ActionEventsPanelProps) {
     return (
         <div className="space-y-3">
             <div className="flex items-center justify-between pb-3 border-b border-slate-100">
-                <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider">
+                <h3 className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
                     Execution Log
                 </h3>
                 <span className="text-xs text-slate-500">

--- a/frontend/src/ui/layout/ActionCardsView.tsx
+++ b/frontend/src/ui/layout/ActionCardsView.tsx
@@ -76,7 +76,7 @@ function ActionCard({ node, onClick }: { node: WorkflowSurfaceNode; onClick: () 
 
             {/* Main Content */}
             <div className="flex-1 mb-4">
-                <h3 className="text-sm font-bold text-slate-800 leading-tight mb-2 group-hover:text-indigo-700 transition-colors">
+                <h3 className="text-sm font-semibold text-slate-800 leading-tight mb-2 group-hover:text-indigo-700 transition-colors">
                     {payload.title || 'Untitled'}
                 </h3>
                 <div className="space-y-1.5">
@@ -95,7 +95,7 @@ function ActionCard({ node, onClick }: { node: WorkflowSurfaceNode; onClick: () 
             <div className="flex justify-between items-center mt-auto">
                 <div className="flex items-center gap-2">
                     {payload.assignees?.[0] && (
-                        <div className="w-5 h-5 rounded-full bg-slate-200 flex items-center justify-center text-[9px] font-bold text-slate-600">
+                        <div className="w-5 h-5 rounded-full bg-slate-200 flex items-center justify-center text-[9px] font-semibold text-slate-600">
                             {payload.assignees[0].name?.slice(0, 2).toUpperCase()}
                         </div>
                     )}
@@ -160,7 +160,7 @@ export function ActionCardsView() {
         return (
             <div className="flex-1 flex items-center justify-center bg-slate-50 text-slate-400">
                 <div className="text-center">
-                    <p className="text-lg font-medium">Select a project to view actions</p>
+                    <p className="text-sm">Select a project to view actions</p>
                     <p className="text-sm mt-1">Choose from the Projects menu</p>
                 </div>
             </div>

--- a/frontend/src/ui/layout/ActionListView.tsx
+++ b/frontend/src/ui/layout/ActionListView.tsx
@@ -65,7 +65,7 @@ export function ActionListView() {
         return (
             <div className="flex-1 flex items-center justify-center bg-slate-50 text-slate-400">
                 <div className="text-center">
-                    <p className="text-lg font-medium">Select a project to view actions</p>
+                    <p className="text-sm">Select a project to view actions</p>
                     <p className="text-sm mt-1">Choose from the Projects menu</p>
                 </div>
             </div>

--- a/frontend/src/ui/layout/ProjectWorkflowView.tsx
+++ b/frontend/src/ui/layout/ProjectWorkflowView.tsx
@@ -499,14 +499,14 @@ export function ProjectWorkflowView() {
                 {!activeProjectId ? (
                     <div className="flex-1 flex items-center justify-center bg-slate-50 text-slate-400">
                         <div className="text-center">
-                            <p className="text-lg font-medium">No project selected</p>
+                            <p className="text-sm">No project selected</p>
                             <p className="text-sm">Select a project from the top menu</p>
                         </div>
                     </div>
                 ) : !project ? (
                     <div className="flex-1 flex items-center justify-center bg-slate-50 text-slate-400">
                         <div className="text-center">
-                            <p className="text-lg font-medium">Loading project…</p>
+                            <p className="text-sm">Loading project…</p>
                         </div>
                     </div>
                 ) : (

--- a/frontend/src/ui/layout/Workspace.tsx
+++ b/frontend/src/ui/layout/Workspace.tsx
@@ -188,7 +188,7 @@ function SubprocessSection({ subprocess }: SubprocessSectionProps) {
   return (
     <div className="pl-4 border-l border-slate-200 ml-2 mt-4">
       <div className="flex items-center justify-between mb-3">
-        <h4 className="text-lg font-bold text-slate-700">{subprocess.title}</h4>
+        <h4 className="text-sm font-semibold text-slate-700">{subprocess.title}</h4>
       </div>
       <div className="space-y-3">
         {children.map((task) => (
@@ -216,7 +216,7 @@ function StageSection({ stage }: StageSectionProps) {
   return (
     <div className={`mb-8 p-4 rounded-lg border ${isCompleted ? 'border-green-200 bg-green-50/50' : 'border-slate-200 bg-white'}`}>
       <div className="flex items-center justify-between">
-        <h3 className="text-xl font-bold text-slate-800 cursor-pointer" onClick={() => setIsExpanded(!isExpanded)}>
+        <h3 className="text-base font-semibold text-slate-800 cursor-pointer" onClick={() => setIsExpanded(!isExpanded)}>
           {stage.title}
         </h3>
         <div className="flex items-center gap-2">
@@ -283,7 +283,7 @@ export function Workspace() {
     return (
       <main className="flex-1 bg-slate-50 flex items-center justify-center">
         <div className="text-center text-slate-400">
-          <p className="text-lg font-medium">Select a project to view its workflow</p>
+          <p className="text-sm">Select a project to view its workflow</p>
           <p className="text-sm mt-1">Choose from the top menu</p>
         </div>
       </main>
@@ -298,7 +298,7 @@ export function Workspace() {
       {/* Project Header - could be more elaborate */}
       {project && (
         <div className="px-6 py-4 border-b border-slate-100 bg-white flex-shrink-0">
-          <h1 className="text-2xl font-bold text-slate-800">{project.title} Workflow</h1>
+          <h1 className="text-xl font-semibold text-slate-800">{project.title} Workflow</h1>
           {project.description ? <p className="text-sm text-slate-600">{String(project.description)}</p> : null}
         </div>
       )}
@@ -307,7 +307,7 @@ export function Workspace() {
       <div className="flex-1 overflow-y-auto bg-slate-50 p-6 custom-scroll">
         {stages.length === 0 ? (
           <div className="text-center text-slate-400">
-            <p className="text-lg font-medium">No stages defined for this project</p>
+            <p className="text-sm">No stages defined for this project</p>
             {/* Add button to create first stage? */}
           </div>
         ) : (

--- a/frontend/src/ui/molecules/MillerColumn.tsx
+++ b/frontend/src/ui/molecules/MillerColumn.tsx
@@ -136,10 +136,10 @@ function HierarchyColumn({
             {/* Column Header */}
             <div className="p-3 bg-slate-50 border-b border-slate-200 flex items-center justify-between">
                 <div className="flex items-center gap-2">
-                    <span className={`w-6 h-6 rounded ${config.bgColor} ${config.textColor} flex items-center justify-center text-xs font-bold`}>
+                    <span className={`w-6 h-6 rounded ${config.bgColor} ${config.textColor} flex items-center justify-center text-xs font-semibold`}>
                         {config.badge}
                     </span>
-                    <span className="text-xs font-bold text-slate-600 uppercase tracking-wider">
+                    <span className="text-xs font-semibold text-slate-600 uppercase tracking-wider">
                         {config.label}
                     </span>
                 </div>
@@ -223,7 +223,7 @@ function GenericColumn({
                 <div className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
                         {headerBadge}
-                        <span className="text-xs font-bold text-slate-600 uppercase tracking-wider">
+                        <span className="text-xs font-semibold text-slate-600 uppercase tracking-wider">
                             {title}
                         </span>
                     </div>

--- a/frontend/src/ui/molecules/PropertySection.tsx
+++ b/frontend/src/ui/molecules/PropertySection.tsx
@@ -73,7 +73,7 @@ export function PropertySection({
                     {icon && <span className="text-slate-400">{icon}</span>}
 
                     {/* Title */}
-                    <h4 className="text-xs font-bold text-slate-400 uppercase">
+                    <h4 className="text-xs font-semibold text-slate-400 uppercase">
                         {title}
                     </h4>
 

--- a/frontend/src/ui/molecules/ReferenceStatusBadge.tsx
+++ b/frontend/src/ui/molecules/ReferenceStatusBadge.tsx
@@ -83,7 +83,7 @@ export function ReferenceStatusBadge({
     return (
         <span
             className={clsx(
-                'inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-bold uppercase shrink-0',
+                'inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase shrink-0',
                 config.bgClass,
                 config.textClass,
                 className

--- a/frontend/src/ui/overlay/views/ActionInspectorOverlay.tsx
+++ b/frontend/src/ui/overlay/views/ActionInspectorOverlay.tsx
@@ -114,14 +114,14 @@ export function ActionInspectorOverlay({ actionId }: ActionInspectorOverlayProps
             <div className="flex items-start justify-between mb-6">
                 <div>
                     <div className="flex items-center gap-2 mb-1">
-                        <span className="px-2 py-0.5 text-[10px] font-bold bg-purple-100 text-purple-700 border border-purple-200 rounded uppercase">
+                        <span className="px-2 py-0.5 text-[10px] font-semibold bg-purple-100 text-purple-700 border border-purple-200 rounded uppercase">
                             ACTION
                         </span>
                         <span className="text-xs text-slate-400 font-mono">
                             {action.id.slice(0, 8)}
                         </span>
                     </div>
-                    <h2 className="text-xl font-bold text-slate-800">{getTitle()}</h2>
+                    <h2 className="text-base font-semibold text-slate-800">{getTitle()}</h2>
                     <div className="flex items-center gap-2 mt-1">
                         <Zap size={12} className="text-purple-500" />
                         <span className="text-sm text-purple-700 font-medium">{action.type}</span>
@@ -144,7 +144,7 @@ export function ActionInspectorOverlay({ actionId }: ActionInspectorOverlayProps
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                 {/* Left: Declared Intent */}
                 <section className="inspector-card bg-white border border-slate-200 rounded-lg p-4">
-                    <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-3 flex items-center gap-2">
+                    <h3 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3 flex items-center gap-2">
                         <div className="w-1.5 h-1.5 bg-purple-500 rounded-full" />
                         Declared Intent
                     </h3>
@@ -197,7 +197,7 @@ export function ActionInspectorOverlay({ actionId }: ActionInspectorOverlayProps
                 {/* Right: Interpreted As (Events) */}
                 <section className="inspector-card bg-white border border-slate-200 rounded-lg p-4">
                     <div className="flex items-center justify-between mb-3">
-                        <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider flex items-center gap-2">
+                        <h3 className="text-xs font-semibold text-slate-400 uppercase tracking-wider flex items-center gap-2">
                             <ArrowDownRight size={12} className="text-slate-400" />
                             Interpreted As
                         </h3>

--- a/frontend/src/ui/overlay/views/ProjectLibraryOverlay.tsx
+++ b/frontend/src/ui/overlay/views/ProjectLibraryOverlay.tsx
@@ -61,7 +61,7 @@ export function ProjectLibraryOverlay({ projectId, projectTitle }: ProjectLibrar
           <Library className="w-5 h-5 text-purple-600" />
         </div>
         <div>
-          <h2 className="text-lg font-semibold text-slate-800">
+          <h2 className="text-base font-semibold text-slate-800">
             Project Template Library
           </h2>
           {projectTitle && (

--- a/frontend/src/ui/overlay/views/StartCollectionModal.tsx
+++ b/frontend/src/ui/overlay/views/StartCollectionModal.tsx
@@ -42,7 +42,7 @@ export function StartCollectionModal({ onClose, onSubmit }: StartCollectionModal
                     <FolderPlus size={24} className="text-amber-600" />
                 </div>
                 <div>
-                    <h2 className="text-lg font-semibold text-slate-800">Start New Collection</h2>
+                    <h2 className="text-base font-semibold text-slate-800">Start New Collection</h2>
                     <p className="text-sm text-slate-500">
                         Create a collection to gather items for export
                     </p>

--- a/frontend/src/ui/overlay/views/ViewDefinitionOverlay.tsx
+++ b/frontend/src/ui/overlay/views/ViewDefinitionOverlay.tsx
@@ -104,10 +104,10 @@ export function ViewDefinitionOverlay({ recordId, definitionId }: ViewDefinition
             {styling.icon || definition.name.charAt(0).toUpperCase()}
           </div>
           <div>
-            <div className="text-[10px] font-bold text-slate-400 uppercase mb-1">
+            <div className="text-[10px] font-semibold text-slate-400 uppercase mb-1">
               Record Definition
             </div>
-            <h2 className="text-xl font-bold text-slate-800">{definition.name}</h2>
+            <h2 className="text-base font-semibold text-slate-800">{definition.name}</h2>
             {definition.derived_from_id && (
               <div className="text-xs text-slate-400 mt-1">
                 Derived from another definition
@@ -173,7 +173,7 @@ export function ViewDefinitionOverlay({ recordId, definitionId }: ViewDefinition
               >
                 {/* Type badge */}
                 <span
-                  className={`text-[10px] font-bold uppercase px-2 py-0.5 rounded ${
+                  className={`text-[10px] font-semibold uppercase px-2 py-0.5 rounded ${
                     FIELD_TYPE_COLORS[field.type] || 'bg-slate-100 text-slate-600'
                   }`}
                 >

--- a/frontend/src/ui/panels/ActionsPanel.tsx
+++ b/frontend/src/ui/panels/ActionsPanel.tsx
@@ -79,7 +79,7 @@ export function ActionsPanel() {
                         {activeTab === 'definitions' ? (
                             <div className="h-full flex items-center justify-center text-slate-400">
                                 <div className="text-center">
-                                    <p className="text-lg font-medium text-slate-600">Action Definitions</p>
+                                    <p className="text-sm text-slate-600">Action Definitions</p>
                                     <p>Select a definition from the sidebar to view its schema.</p>
                                     <p className="text-xs mt-2">Use the Composer panel to create new definitions.</p>
                                 </div>

--- a/frontend/src/ui/panels/EventsPanel.tsx
+++ b/frontend/src/ui/panels/EventsPanel.tsx
@@ -21,7 +21,7 @@ export function EventsPanel() {
         <div className="flex flex-col h-full bg-slate-50 overflow-hidden">
             {/* Page Header */}
             <div className="h-12 border-b border-slate-200 bg-white flex items-center justify-between px-4 shrink-0">
-                <h1 className="text-lg font-semibold text-slate-800 flex items-center gap-2">
+                <h1 className="text-xl font-semibold text-slate-800 flex items-center gap-2">
                     <Activity size={20} className="text-emerald-500" />
                     Events
                 </h1>

--- a/frontend/src/ui/panels/MailPanel.tsx
+++ b/frontend/src/ui/panels/MailPanel.tsx
@@ -217,7 +217,7 @@ export function MailPanel(_props: IDockviewPanelProps) {
                 ) : isError ? (
                     <div className="flex flex-col items-center justify-center h-full text-center">
                         <AlertCircle className="text-red-400 mb-3" size={40} />
-                        <h3 className="text-lg font-medium text-slate-900 mb-1">Failed to load emails</h3>
+                        <h3 className="text-sm text-slate-900 mb-1">Failed to load emails</h3>
                         <p className="text-sm text-slate-500 mb-4">
                             {error instanceof Error ? error.message : 'Could not connect to AutoHelper'}
                         </p>
@@ -231,7 +231,7 @@ export function MailPanel(_props: IDockviewPanelProps) {
                 ) : data?.emails.length === 0 ? (
                     <div className="flex flex-col items-center justify-center h-full text-center">
                         <Mail className="text-slate-300 mb-3" size={40} />
-                        <h3 className="text-lg font-medium text-slate-900 mb-1">No emails yet</h3>
+                        <h3 className="text-sm text-slate-900 mb-1">No emails yet</h3>
                         <p className="text-sm text-slate-500">Emails will appear here once ingested</p>
                     </div>
                 ) : (

--- a/frontend/src/ui/panels/RecordsPanel.tsx
+++ b/frontend/src/ui/panels/RecordsPanel.tsx
@@ -78,7 +78,7 @@ export function RecordsPanel() {
                         {activeTab === 'definitions' ? (
                             <div className="h-full flex items-center justify-center text-slate-400">
                                 <div className="text-center">
-                                    <p className="text-lg font-medium text-slate-600">Record Definitions</p>
+                                    <p className="text-sm text-slate-600">Record Definitions</p>
                                     <p>Select a definition from the sidebar to view its schema.</p>
                                 </div>
                             </div>

--- a/frontend/src/ui/projectLog/ProjectLogView.tsx
+++ b/frontend/src/ui/projectLog/ProjectLogView.tsx
@@ -160,7 +160,7 @@ export function ProjectLogView() {
     return (
       <div className="flex-1 flex items-center justify-center bg-slate-50 text-slate-400">
         <div className="text-center">
-          <p className="text-lg font-medium">No project selected</p>
+          <p className="text-sm">No project selected</p>
           <p className="text-sm">Select a project from the top menu</p>
         </div>
       </div>
@@ -181,7 +181,7 @@ export function ProjectLogView() {
       <div className="h-12 border-b border-slate-200 bg-white px-4 flex items-center justify-between shrink-0">
         <div className="flex items-center gap-3">
           <div>
-            <div className="text-[10px] font-bold text-slate-400 uppercase tracking-wider">
+            <div className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider">
               Project Log
             </div>
             {/* Subprocess dropdown */}
@@ -206,7 +206,7 @@ export function ProjectLogView() {
                       onClick={() => setIsSubprocessDropdownOpen(false)}
                     />
                     <div className="absolute top-full left-0 mt-1 w-56 bg-white border border-slate-200 rounded-lg shadow-lg z-20 py-1 max-h-64 overflow-y-auto">
-                      <div className="px-3 py-1.5 text-[10px] font-bold text-slate-400 uppercase">
+                      <div className="px-3 py-1.5 text-[10px] font-semibold text-slate-400 uppercase">
                         Subprocesses
                       </div>
                       {subprocesses.map((sp) => (

--- a/frontend/src/ui/projectLog/eventFormatters.tsx
+++ b/frontend/src/ui/projectLog/eventFormatters.tsx
@@ -89,7 +89,7 @@ export const eventFormatters: Record<string, EventFormatter> = {
     icon: Play,
     dotBgClass: 'bg-indigo-100',
     dotTextClass: 'text-indigo-600',
-    labelClass: 'text-indigo-700 font-bold',
+    labelClass: 'text-indigo-700 font-semibold',
     isMajor: true,
     summarize: () => null,
   },
@@ -111,7 +111,7 @@ export const eventFormatters: Record<string, EventFormatter> = {
     icon: CheckCircle,
     dotBgClass: 'bg-emerald-100',
     dotTextClass: 'text-emerald-600',
-    labelClass: 'text-emerald-700 font-bold',
+    labelClass: 'text-emerald-700 font-semibold',
     isMajor: true,
     summarize: () => null,
   },
@@ -122,7 +122,7 @@ export const eventFormatters: Record<string, EventFormatter> = {
     icon: AlertOctagon,
     dotBgClass: 'bg-red-100',
     dotTextClass: 'text-red-600',
-    labelClass: 'text-red-700 font-bold',
+    labelClass: 'text-red-700 font-semibold',
     isMajor: true,
     summarize: (payload) => {
       const reason = payload.reason as string | undefined;

--- a/frontend/src/ui/records/RecordGrid.tsx
+++ b/frontend/src/ui/records/RecordGrid.tsx
@@ -282,7 +282,7 @@ export function RecordGrid({ definitionId }: RecordGridProps) {
         ) : paginatedRecords.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full text-slate-400">
             <FolderOpen size={48} className="mb-3 opacity-50" />
-            <p className="text-lg font-medium">No records found</p>
+            <p className="text-sm">No records found</p>
             <p className="text-sm mt-1">
               {searchQuery
                 ? 'Try a different search term'

--- a/frontend/src/ui/registry/RegistryPageHeader.tsx
+++ b/frontend/src/ui/registry/RegistryPageHeader.tsx
@@ -56,7 +56,7 @@ export function RegistryPageHeader({
             <div className="flex items-center gap-3">
                 <div className="flex items-center gap-2">
                     <Icon size={20} className="text-slate-500" />
-                    <h1 className="text-lg font-semibold text-slate-800">{title}</h1>
+                    <h1 className="text-xl font-semibold text-slate-800">{title}</h1>
                 </div>
 
                 {showCreateButton && onCreateClick && (

--- a/frontend/src/ui/semantic/FieldDefinitionEditor.tsx
+++ b/frontend/src/ui/semantic/FieldDefinitionEditor.tsx
@@ -139,7 +139,7 @@ export function FieldDefinitionEditor({ field }: FieldDefinitionEditorProps) {
             {/* Header */}
             <div className="h-14 px-6 border-b border-slate-200 flex items-center justify-between bg-white">
                 <div>
-                    <h2 className="text-lg font-semibold text-slate-800">{label || field.label}</h2>
+                    <h2 className="text-base font-semibold text-slate-800">{label || field.label}</h2>
                     <div className="text-xs text-slate-400 flex items-center gap-2">
                         <span>{definition.name}</span>
                         <span>•</span>

--- a/frontend/src/ui/semantic/FieldInstancesReview.tsx
+++ b/frontend/src/ui/semantic/FieldInstancesReview.tsx
@@ -147,7 +147,7 @@ export function FieldInstancesReview({ field }: FieldInstancesReviewProps) {
         return (
             <div className="flex-1 flex items-center justify-center text-slate-400">
                 <div className="text-center">
-                    <p className="text-lg font-medium text-slate-600">Node Metadata Field</p>
+                    <p className="text-sm text-slate-600">Node Metadata Field</p>
                     <p className="text-sm mt-1">
                         This field appears in hierarchy nodes, not records.
                     </p>
@@ -172,7 +172,7 @@ export function FieldInstancesReview({ field }: FieldInstancesReviewProps) {
             {/* Header */}
             <div className="h-14 px-6 border-b border-slate-200 flex items-center justify-between bg-white">
                 <div>
-                    <h2 className="text-lg font-semibold text-slate-800">
+                    <h2 className="text-base font-semibold text-slate-800">
                         {field.label} Instances
                     </h2>
                     <div className="text-xs text-slate-400">

--- a/frontend/src/ui/semantic/LinksManager.tsx
+++ b/frontend/src/ui/semantic/LinksManager.tsx
@@ -68,7 +68,7 @@ export function LinksManager({ recordId }: LinksManagerProps) {
             <div className="bg-gradient-to-br from-purple-50 to-pink-50 border border-purple-100 rounded-lg p-4">
                 <div className="flex items-center gap-2 mb-2">
                     <ExternalLink size={16} className="text-purple-600" />
-                    <span className="text-sm font-bold text-purple-900">Record Links</span>
+                    <span className="text-sm font-semibold text-purple-900">Record Links</span>
                 </div>
                 <p className="text-xs text-purple-700 leading-relaxed mb-3">
                     Links connect this record to other records in the system. Use{' '}
@@ -78,7 +78,7 @@ export function LinksManager({ recordId }: LinksManagerProps) {
 
                 <button
                     onClick={() => openOverlay('create-link', { sourceRecordId: recordId })}
-                    className="w-full py-2 bg-white border border-purple-200 text-purple-700 rounded text-xs font-bold hover:bg-purple-50 hover:border-purple-300 transition-all flex items-center justify-center gap-2 shadow-sm"
+                    className="w-full py-2 bg-white border border-purple-200 text-purple-700 rounded text-xs font-semibold hover:bg-purple-50 hover:border-purple-300 transition-all flex items-center justify-center gap-2 shadow-sm"
                 >
                     <ExternalLink size={12} />
                     Link Another Record
@@ -101,7 +101,7 @@ export function LinksManager({ recordId }: LinksManagerProps) {
 
             {/* Outgoing Links */}
             <div className="space-y-3">
-                <h4 className="text-xs font-bold text-slate-400 uppercase border-b border-slate-100 pb-2 flex items-center gap-2">
+                <h4 className="text-xs font-semibold text-slate-400 uppercase border-b border-slate-100 pb-2 flex items-center gap-2">
                     <span className="text-blue-500">→</span> Outgoing Links ({outgoing.length})
                 </h4>
 
@@ -121,7 +121,7 @@ export function LinksManager({ recordId }: LinksManagerProps) {
 
             {/* Incoming Links */}
             <div className="space-y-3">
-                <h4 className="text-xs font-bold text-slate-400 uppercase border-b border-slate-100 pb-2 flex items-center gap-2">
+                <h4 className="text-xs font-semibold text-slate-400 uppercase border-b border-slate-100 pb-2 flex items-center gap-2">
                     <span className="text-green-500">←</span> Incoming Links ({incoming.length})
                 </h4>
 

--- a/frontend/src/ui/semantic/ReferencesManager.tsx
+++ b/frontend/src/ui/semantic/ReferencesManager.tsx
@@ -53,7 +53,7 @@ export function ReferencesManager({ actionId }: ReferencesManagerProps) {
             <div className="bg-gradient-to-br from-blue-50 to-indigo-50 border border-blue-100 rounded-lg p-4">
                 <div className="flex items-center gap-2 mb-2">
                     <Link2 size={16} className="text-blue-600" />
-                    <span className="text-sm font-bold text-blue-900">Action References</span>
+                    <span className="text-sm font-semibold text-blue-900">Action References</span>
                 </div>
                 <p className="text-xs text-blue-700 leading-relaxed">
                     References link this action to record fields. Values are resolved dynamically
@@ -63,7 +63,7 @@ export function ReferencesManager({ actionId }: ReferencesManagerProps) {
 
             {/* References List */}
             <div className="space-y-3">
-                <h4 className="text-xs font-bold text-slate-400 uppercase border-b border-slate-100 pb-2">
+                <h4 className="text-xs font-semibold text-slate-400 uppercase border-b border-slate-100 pb-2">
                     Linked References ({references?.length || 0})
                 </h4>
 
@@ -132,7 +132,7 @@ function ReferenceCard({ reference, actionId }: ReferenceCardProps) {
                 </div>
                 <div className="flex items-center gap-1">
                     <span className={clsx(
-                        'text-[10px] font-bold uppercase px-1.5 py-0.5 rounded shrink-0',
+                        'text-[10px] font-semibold uppercase px-1.5 py-0.5 rounded shrink-0',
                         'bg-blue-100 text-blue-700'
                     )}>
                         {reference.mode}

--- a/frontend/src/ui/semantic/SchemaEditor.tsx
+++ b/frontend/src/ui/semantic/SchemaEditor.tsx
@@ -268,7 +268,7 @@ export function SchemaEditor({ itemId, isNode }: SchemaEditorProps) {
             <div className="bg-slate-800 text-slate-100 rounded-lg p-4 shadow-md">
                 <div className="flex justify-between items-start">
                     <div>
-                        <div className="text-[10px] text-slate-400 font-bold uppercase mb-1">
+                        <div className="text-[10px] text-slate-400 font-semibold uppercase mb-1">
                             Editing Class Definition
                         </div>
                         {isEditingName ? (
@@ -277,7 +277,7 @@ export function SchemaEditor({ itemId, isNode }: SchemaEditorProps) {
                                     type="text"
                                     value={editedName}
                                     onChange={(e) => setEditedName(e.target.value)}
-                                    className="bg-slate-700 text-white border border-slate-600 rounded px-2 py-0.5 text-lg font-bold capitalize w-48 focus:outline-none focus:border-blue-500"
+                                    className="bg-slate-700 text-white border border-slate-600 rounded px-2 py-0.5 text-base font-semibold capitalize w-48 focus:outline-none focus:border-blue-500"
                                     autoFocus
                                     onKeyDown={(e) => {
                                         if (e.key === 'Enter') handleSaveName();
@@ -299,7 +299,7 @@ export function SchemaEditor({ itemId, isNode }: SchemaEditorProps) {
                             </div>
                         ) : (
                             <div className="flex items-center gap-2 group">
-                                <div className="text-lg font-bold capitalize">
+                                <div className="text-base font-semibold capitalize">
                                     {definition?.name || nodeType} Record
                                 </div>
                                 {definition && (
@@ -340,7 +340,7 @@ export function SchemaEditor({ itemId, isNode }: SchemaEditorProps) {
             </div>
 
             <div className="space-y-3">
-                <h4 className="text-xs font-bold text-slate-400 uppercase border-b border-slate-100 pb-2">
+                <h4 className="text-xs font-semibold text-slate-400 uppercase border-b border-slate-100 pb-2">
                     Defined Fields
                 </h4>
 
@@ -421,7 +421,7 @@ export function SchemaEditor({ itemId, isNode }: SchemaEditorProps) {
             {/* Styling Override */}
             {definition && (
                 <div className="space-y-3 pt-4 border-t border-slate-100">
-                    <h4 className="text-xs font-bold text-slate-400 uppercase">Class Styling</h4>
+                    <h4 className="text-xs font-semibold text-slate-400 uppercase">Class Styling</h4>
                     <div className="flex items-center gap-4">
                         {/* Emoji Picker */}
                         <div className="flex items-center gap-2">

--- a/frontend/src/ui/sidebars/HierarchySidebar.tsx
+++ b/frontend/src/ui/sidebars/HierarchySidebar.tsx
@@ -77,7 +77,7 @@ export function HierarchySidebar() {
     >
       {/* Project Selector */}
       <div className="p-3 border-b border-slate-200 bg-white">
-        <label className="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1 block">
+        <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider mb-1 block">
           Project
         </label>
         <Menu>
@@ -137,7 +137,7 @@ export function HierarchySidebar() {
       </div>
       {processes.length > 0 && (
         <div className="p-3 border-b border-slate-200 bg-white">
-          <label className="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1 block">
+          <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider mb-1 block">
             Process {processes.length > 1 && `(${processes.length})`}
           </label>
           <div className="relative">

--- a/frontend/src/ui/sidebars/ProjectSidebar.tsx
+++ b/frontend/src/ui/sidebars/ProjectSidebar.tsx
@@ -75,7 +75,7 @@ export function ProjectSidebar() {
         <div className="flex flex-col h-full bg-slate-50 overflow-hidden relative" style={{ position: 'relative' }}>
             {/* Project Selector */}
             <div className="p-3 border-b border-slate-200 bg-white">
-                <label className="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1 block">
+                <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider mb-1 block">
                     Project
                 </label>
                 <Menu>
@@ -135,7 +135,7 @@ export function ProjectSidebar() {
             </div>
             {processes.length > 0 && (
                 <div className="p-3 border-b border-slate-200 bg-white">
-                    <label className="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1 block">
+                    <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider mb-1 block">
                         Process {processes.length > 1 && `(${processes.length})`}
                     </label>
                     <div className="relative">

--- a/frontend/src/ui/sidebars/RegistrySidebar.tsx
+++ b/frontend/src/ui/sidebars/RegistrySidebar.tsx
@@ -143,7 +143,7 @@ export function RegistrySidebar({
                             >
                                 <div className="flex items-center gap-2">
                                     <FolderOpen size={14} className="text-blue-500" />
-                                    <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">
+                                    <span className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
                                         Data Definitions
                                     </span>
                                     <span className="text-[10px] text-slate-400 bg-slate-100 px-1.5 py-0.5 rounded">
@@ -258,7 +258,7 @@ export function RegistrySidebar({
                             >
                                 <div className="flex items-center gap-2">
                                     <Zap size={14} className="text-amber-500" />
-                                    <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">
+                                    <span className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
                                         Action Types
                                     </span>
                                     <span className="text-[10px] text-slate-400 bg-slate-100 px-1.5 py-0.5 rounded">
@@ -357,7 +357,7 @@ export function RegistrySidebar({
                             >
                                 <div className="flex items-center gap-2">
                                     <Activity size={14} className="text-blue-500" />
-                                    <span className="text-xs font-bold text-slate-500 uppercase tracking-wider">
+                                    <span className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
                                         Events & Facts
                                     </span>
                                 </div>

--- a/frontend/src/ui/table-core/UniversalTableCore.tsx
+++ b/frontend/src/ui/table-core/UniversalTableCore.tsx
@@ -389,7 +389,7 @@ export function UniversalTableCore({
                                 {column.renderHeader ? (
                                     column.renderHeader()
                                 ) : (
-                                    <span className="text-[10px] font-bold text-slate-500 uppercase tracking-wider truncate">
+                                    <span className="text-[10px] font-semibold text-slate-500 uppercase tracking-wider truncate">
                                         {column.header}
                                     </span>
                                 )}

--- a/frontend/src/ui/table/TableCell.tsx
+++ b/frontend/src/ui/table/TableCell.tsx
@@ -64,7 +64,7 @@ export const TableHeaderCell = forwardRef<HTMLDivElement, TableHeaderCellProps>(
         )}
         {...props}
       >
-        <span className="text-[10px] font-bold text-slate-500 uppercase tracking-wider truncate">
+        <span className="text-[10px] font-semibold text-slate-500 uppercase tracking-wider truncate">
           {children}
         </span>
         {sortable && sortDir && (

--- a/frontend/src/ui/tables/DataTable.tsx
+++ b/frontend/src/ui/tables/DataTable.tsx
@@ -193,7 +193,7 @@ function ColumnHeader<T>({ column, columnWidth, sortKey, sortDir, onSort, onResi
             style={{ width, flex: columnWidth === 'flex' ? 1 : undefined }}
             onClick={handleClick}
         >
-            <span className="text-[10px] font-bold text-slate-500 uppercase tracking-wider truncate">
+            <span className="text-[10px] font-semibold text-slate-500 uppercase tracking-wider truncate">
                 {column.label}
             </span>
             {column.sortable && isSorted && (

--- a/frontend/src/ui/tables/UniversalTableView.tsx
+++ b/frontend/src/ui/tables/UniversalTableView.tsx
@@ -133,7 +133,7 @@ function ColumnPicker({ allColumns, visibleKeys, onToggle }: ColumnPickerProps) 
                 <>
                     <div className="fixed inset-0 z-10" onClick={() => setIsOpen(false)} />
                     <div className="absolute top-full right-0 mt-1 w-48 bg-white border border-slate-200 rounded-lg shadow-lg z-20 py-1 max-h-64 overflow-y-auto">
-                        <div className="px-3 py-1.5 text-[10px] font-bold text-slate-400 uppercase">
+                        <div className="px-3 py-1.5 text-[10px] font-semibold text-slate-400 uppercase">
                             Visible Columns
                         </div>
                         {allColumns.map((col) => (
@@ -486,7 +486,7 @@ export function UniversalTableView({
                     </div>
                 ) : !selectedDefinitionId ? (
                     <div className="flex flex-col items-center justify-center h-64 text-slate-400">
-                        <p className="text-lg font-medium">Select a record type</p>
+                        <p className="text-sm">Select a record type</p>
                         <p className="text-sm">Choose a definition from the dropdown to view records</p>
                     </div>
                 ) : (

--- a/frontend/src/ui/workspace/content/MailContent.tsx
+++ b/frontend/src/ui/workspace/content/MailContent.tsx
@@ -314,7 +314,7 @@ export function MailContent() {
                 ) : isError ? (
                     <div className="flex flex-col items-center justify-center h-full text-center">
                         <AlertCircle className="text-red-400 mb-3" size={40} />
-                        <h3 className="text-lg font-medium text-slate-900 mb-1">Failed to load emails</h3>
+                        <h3 className="text-sm text-slate-900 mb-1">Failed to load emails</h3>
                         <p className="text-sm text-slate-500 mb-4">
                             {error instanceof Error ? error.message : 'Could not connect to AutoHelper'}
                         </p>
@@ -328,7 +328,7 @@ export function MailContent() {
                 ) : !data?.emails?.length ? (
                     <div className="flex flex-col items-center justify-center h-full text-center">
                         <Mail className="text-slate-300 mb-3" size={40} />
-                        <h3 className="text-lg font-medium text-slate-900 mb-1">No emails yet</h3>
+                        <h3 className="text-sm text-slate-900 mb-1">No emails yet</h3>
                         <p className="text-sm text-slate-500">Emails will appear here once ingested</p>
                     </div>
                 ) : (

--- a/frontend/src/workflows/artcollector/components/PrintPreviewView.tsx
+++ b/frontend/src/workflows/artcollector/components/PrintPreviewView.tsx
@@ -271,7 +271,7 @@ function TearsheetPagePreview({
         {/* Sidebar */}
         <div className="flex flex-col">
           <div>
-            <h1 className="text-2xl font-bold uppercase tracking-wide text-slate-800">
+            <h1 className="text-xl font-semibold uppercase tracking-wide text-slate-800">
               Artist Name
             </h1>
             <p className="text-sm text-slate-500 mt-1">(Region)</p>
@@ -421,7 +421,7 @@ function TearsheetPagePrint({
                 </div>
                 {artifact?.metadata?.title && (
                   <figcaption style={{ fontSize: '9pt', marginTop: '8px' }}>
-                    <span className="font-bold italic">{artifact.metadata.title}</span>
+                    <span className="font-semibold italic">{artifact.metadata.title}</span>
                   </figcaption>
                 )}
               </figure>

--- a/frontend/src/workflows/export/panels/CollectionPanel.tsx
+++ b/frontend/src/workflows/export/panels/CollectionPanel.tsx
@@ -38,7 +38,7 @@ export function CollectionPanel() {
             {/* Header */}
             <div className="p-3 border-b border-slate-200 bg-slate-50">
                 <div className="flex items-center justify-between">
-                    <span className="text-xs font-bold text-slate-600 uppercase tracking-wider">
+                    <span className="text-xs font-semibold text-slate-600 uppercase tracking-wider">
                         Collections
                     </span>
                     <button

--- a/frontend/src/workflows/import/components/LogPreview.tsx
+++ b/frontend/src/workflows/import/components/LogPreview.tsx
@@ -101,7 +101,7 @@ export function LogPreview({ plan, selectedRecordId, onSelect }: LogPreviewProps
         }[type] || 'bg-slate-100 text-slate-700';
 
         return (
-            <span className={`px-1.5 py-0.5 text-[10px] font-bold uppercase rounded ${styles}`}>
+            <span className={`px-1.5 py-0.5 text-[10px] font-semibold uppercase rounded ${styles}`}>
                 {type}
             </span>
         );

--- a/frontend/src/workflows/import/components/ProjectionSelector.tsx
+++ b/frontend/src/workflows/import/components/ProjectionSelector.tsx
@@ -36,7 +36,7 @@ export function ProjectionSelector({
     return (
         <div className="h-12 bg-white border-b border-slate-200 flex items-center px-4 gap-3">
             <Eye className="w-4 h-4 text-slate-400" />
-            <span className="text-xs font-bold text-slate-500 uppercase">View as:</span>
+            <span className="text-xs font-semibold text-slate-500 uppercase">View as:</span>
 
             <div className="flex gap-1">
                 {availableProjections.map((projection) => (

--- a/frontend/src/workflows/import/components/StagePreview.tsx
+++ b/frontend/src/workflows/import/components/StagePreview.tsx
@@ -57,7 +57,7 @@ export function StagePreview({
                     {/* Stage header */}
                     <div className="px-4 py-3 bg-slate-50 border-b border-slate-200 flex items-center gap-2">
                         <Layers className="w-4 h-4 text-blue-500" />
-                        <h3 className="text-sm font-bold text-slate-700">{stage.label}</h3>
+                        <h3 className="text-sm font-semibold text-slate-700">{stage.label}</h3>
                         <span className="text-xs text-slate-400 bg-slate-200 px-1.5 py-0.5 rounded">
                             {stage.items.length} items
                         </span>

--- a/frontend/src/workflows/import/panels/ImportSidebar.tsx
+++ b/frontend/src/workflows/import/panels/ImportSidebar.tsx
@@ -165,7 +165,7 @@ export function ImportSidebar({ width, sourceType, onSourceChange, session, onSe
                 <div className="flex-1 flex flex-col overflow-hidden">
                     {/* Session Header */}
                     <div className="p-4 border-b border-slate-200">
-                        <div className="text-[10px] font-bold text-slate-400 uppercase tracking-wider mb-1">
+                        <div className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider mb-1">
                             Active Session
                         </div>
                         <div className="text-sm font-medium text-slate-800">{session.parser_name}</div>
@@ -251,7 +251,7 @@ export function ImportSidebar({ width, sourceType, onSourceChange, session, onSe
                     <>
                         {/* Parser Selection */}
                         <div className="p-4 border-b border-slate-100">
-                            <label className="text-[10px] font-bold text-slate-400 uppercase tracking-wider">
+                            <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider">
                                 Parser
                             </label>
                             <select
@@ -267,7 +267,7 @@ export function ImportSidebar({ width, sourceType, onSourceChange, session, onSe
 
                         {/* File Upload */}
                         <div className="p-4 border-b border-slate-100">
-                            <label className="text-[10px] font-bold text-slate-400 uppercase tracking-wider">
+                            <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider">
                                 Upload File
                             </label>
                             <input
@@ -290,7 +290,7 @@ export function ImportSidebar({ width, sourceType, onSourceChange, session, onSe
                         <div className="flex-1 p-4 flex flex-col min-h-0">
                             <div className="flex items-center gap-1 mb-2">
                                 <ClipboardPaste className="w-3 h-3 text-slate-400" />
-                                <label className="text-[10px] font-bold text-slate-400 uppercase tracking-wider">
+                                <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider">
                                     Paste Data
                                 </label>
                             </div>

--- a/frontend/src/workflows/import/views/ImportWorkbenchContent.tsx
+++ b/frontend/src/workflows/import/views/ImportWorkbenchContent.tsx
@@ -82,7 +82,7 @@ export function ImportWorkbenchContent() {
                     <div className="w-16 h-16 mx-auto bg-slate-100 rounded-full flex items-center justify-center mb-4">
                         <FileSpreadsheet className="w-8 h-8 text-slate-400" />
                     </div>
-                    <p className="text-lg font-medium text-slate-500 mb-2">
+                    <p className="text-sm text-slate-500 mb-2">
                         No import session active
                     </p>
                     <p className="text-sm text-slate-400">

--- a/frontend/src/workflows/import/views/MondayPreviewView.tsx
+++ b/frontend/src/workflows/import/views/MondayPreviewView.tsx
@@ -136,7 +136,7 @@ export function MondayPreviewView({
                         {Object.entries(outcomeCounts).map(([outcome, count]) => (
                             <span
                                 key={outcome}
-                                className="px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider bg-slate-100 text-slate-600 rounded"
+                                className="px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-slate-100 text-slate-600 rounded"
                             >
                                 {outcome.replace(/_/g, ' ')}: {count}
                             </span>

--- a/frontend/src/workflows/import/wizard/steps/Step2ConfigureMapping.tsx
+++ b/frontend/src/workflows/import/wizard/steps/Step2ConfigureMapping.tsx
@@ -312,7 +312,7 @@ function TypeBadge({ group, onRoleChange }: TypeBadgeProps) {
             contentClassName="p-1 w-40"
             align="end"
         >
-            <div className="text-[10px] font-bold text-slate-400 px-2 py-1 uppercase">Convert To</div>
+            <div className="text-[10px] font-semibold text-slate-400 px-2 py-1 uppercase">Convert To</div>
             {TYPE_OPTIONS.map(opt => (
                 <button
                     type="button"

--- a/frontend/src/workflows/intake/components/FormSettingsPanel.tsx
+++ b/frontend/src/workflows/intake/components/FormSettingsPanel.tsx
@@ -45,7 +45,7 @@ export function FormSettingsPanel({ settings, onSave, isSaving }: FormSettingsPa
             <div className="bg-white rounded-xl border border-slate-200 overflow-hidden">
                 {/* Header */}
                 <div className="px-6 py-4 border-b border-slate-100 flex items-center justify-between">
-                    <h2 className="text-lg font-semibold text-slate-800">Form Settings</h2>
+                    <h2 className="text-base font-semibold text-slate-800">Form Settings</h2>
                     <Button
                         size="sm"
                         onClick={handleSave}

--- a/frontend/src/workflows/intake/components/IntakeCanvas.tsx
+++ b/frontend/src/workflows/intake/components/IntakeCanvas.tsx
@@ -260,7 +260,7 @@ export function IntakeCanvas({
                 <div className="w-16 h-16 rounded-full bg-slate-100 flex items-center justify-center mb-4">
                     <span className="text-2xl">📝</span>
                 </div>
-                <h3 className="text-lg font-semibold text-slate-700">No blocks yet</h3>
+                <h3 className="text-base font-semibold text-slate-700">No blocks yet</h3>
                 <p className="text-sm text-slate-500 mt-1 mb-6">
                     Add your first question or content block
                 </p>

--- a/frontend/src/workflows/intake/panels/IntakeDetailPanel.tsx
+++ b/frontend/src/workflows/intake/panels/IntakeDetailPanel.tsx
@@ -80,7 +80,7 @@ export function IntakeDetailPanel({ formId, onBack }: IntakeDetailPanelProps) {
           </Button>
         )}
         <div className="flex-1">
-          <h2 className="text-lg font-semibold">{form.title}</h2>
+          <h2 className="text-base font-semibold">{form.title}</h2>
           <div className="text-sm text-slate-500">{form.unique_id}</div>
         </div>
         <Badge variant={form.status === 'active' ? 'success' : 'neutral'}>

--- a/frontend/src/workflows/intake/panels/IntakeListPanel.tsx
+++ b/frontend/src/workflows/intake/panels/IntakeListPanel.tsx
@@ -43,7 +43,7 @@ export function IntakeListPanel({ onSelectForm }: IntakeListPanelProps) {
   return (
     <div className="p-4 space-y-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold">Intake Forms</h2>
+        <h2 className="text-base font-semibold">Intake Forms</h2>
         <Button size="sm" onClick={() => setShowCreate(true)}>
           <Plus className="w-4 h-4 mr-1" />
           New Form


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #313**
  * **PR #314** 👈
    * **PR #315**
      * **PR #316**
        * **PR #317**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Normalize UI typography: use semibold for emphasis and tighten heading scale

### What Changed
- Replaced heavy "bold" emphasis with "semibold" across labels, badges, buttons and small UI chips so emphasis is visually consistent.
- Reduced several heading sizes (e.g., many text-2xl/text-lg → text-xl/text-base or text-sm) across pages, panels and empty-state messages to enforce a tighter type scale and consistent hierarchy.
- Updated counts, badges and status labels to use semibold weight so numeric and status information reads with consistent prominence.

### Impact
`✅ Consistent typography across the app`
`✅ Clearer visual hierarchy in pages, dialogs and empty states`
`✅ More balanced emphasis on labels, badges and counts`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
