### PR TITLE
feat: add AutoArt text + pre-spinner to loading screen

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,6 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AutoArt - Process Management</title>
     <link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;1,8..60,400&family=Source+Sans+3:wght@400;600&family=IBM+Plex+Mono:wght@400&display=swap" rel="stylesheet">
+    <style>
+      @keyframes cymatic-spin { to { transform: rotate(360deg); } }
+      .cymatic-hidden { opacity: 0 !important; transition: opacity 160ms ease-out; }
+    </style>
   </head>
   <body>
     <div id="cymatic-loader-backdrop" style="
@@ -23,10 +27,24 @@
         position: relative;
         box-shadow: 0 1px 3px rgba(0,0,0,0.06);
       ">
+        <div id="cymatic-pre-spinner" style="
+          pointer-events: none; position: absolute; inset: 0;
+          display: flex; align-items: center; justify-content: center;
+        ">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" style="animation: cymatic-spin 1s linear infinite;">
+            <circle cx="12" cy="12" r="10" stroke="#3F5C6E" stroke-width="3" opacity="0.2"/>
+            <path d="M22 12a10 10 0 00-10-10" stroke="#3F5C6E" stroke-width="3" stroke-linecap="round"/>
+          </svg>
+        </div>
         <canvas id="cymatic-loader" style="
           width: 100%; height: 100%; display: block;
+          position: relative; z-index: 1;
         "></canvas>
       </div>
+      <p id="cymatic-loader-text" style="
+        font-family: 'Source Serif 4', serif; font-weight: 600; font-size: 24px;
+        color: #2E2E2C; margin: 20px 0 0; user-select: none;
+      ">AutoArt</p>
     </div>
     <script type="module" src="/cymatic-loader.mjs"></script>
     <div id="root"></div>

--- a/frontend/public/cymatic-loader.mjs
+++ b/frontend/public/cymatic-loader.mjs
@@ -200,7 +200,14 @@
 
   function frame(now) {
     if (!running) return;
-    if (t0 === null) t0 = now;
+    if (t0 === null) {
+      t0 = now;
+      const spinner = document.getElementById('cymatic-pre-spinner');
+      if (spinner) {
+        spinner.classList.add('cymatic-hidden');
+        setTimeout(() => spinner.remove(), 200);
+      }
+    }
 
     const elapsed = (now - t0) / 1000;
     const t01 = (elapsed % DURATION) / DURATION;


### PR DESCRIPTION
## Summary

Adds instant visual feedback and branding to the loading screen while the Chladni canvas computes its first frame.

- **Pre-spinner:** Oxide Blue (`#3F5C6E`) SVG spinner centered in wrapper, visible immediately on page load
  - Track circle at 0.2 opacity + quarter-arc at full opacity
  - `pointer-events: none; position: absolute; inset: 0` — sits behind canvas via z-index
- **Fade-out:** On first animation frame (`t0 === null`), spinner gets `.cymatic-hidden` class (opacity 160ms ease-out), removed from DOM after 200ms
- **"AutoArt" text:** Source Serif 4 at 600/24px, `#2E2E2C`, 20px below wrapper

Depends on PR #326 wrapper structure.


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #326**
  * **PR #327** 👈
    * **PR #328**
      * **PR #329**
        * **PR #330**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->