### PR TITLE
feat: add pairing code input to AutoHelper tray menu

### DIFF
--- a/apps/autohelper/autohelper/gui/pairing.py
+++ b/apps/autohelper/autohelper/gui/pairing.py
@@ -1,0 +1,96 @@
+"""
+Standalone tkinter dialog for entering a 6-digit pairing code.
+
+Called from the pystray menu callback thread, which keeps the tray
+responsive while the dialog blocks.
+
+Falls back to opening the browser settings page if tkinter is
+unavailable (headless Linux, minimal containers).
+"""
+
+from autohelper.shared.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def ask_pairing_code() -> str | None:
+    """Show a modal dialog for the 6-digit pairing code.
+
+    Returns the code string on submit, None on cancel/close.
+    Falls back to opening browser settings if tkinter is missing.
+    """
+    try:
+        import tkinter as tk
+    except ModuleNotFoundError:
+        logger.warning("tkinter not available — opening browser settings instead")
+        from autohelper.gui.popup import open_settings_in_browser
+
+        open_settings_in_browser()
+        return None
+
+    code: str | None = None
+
+    root = tk.Tk()
+    root.title("Pair with AutoArt")
+    root.resizable(False, False)
+    root.attributes("-topmost", True)
+
+    # Center on screen
+    w, h = 320, 150
+    x = (root.winfo_screenwidth() - w) // 2
+    y = (root.winfo_screenheight() - h) // 2
+    root.geometry(f"{w}x{h}+{x}+{y}")
+
+    tk.Label(root, text="Enter 6-digit code from AutoArt", pady=12).pack()
+
+    # Validation: digits only, max 6 chars
+    vcmd = (root.register(lambda s: s.isdigit() and len(s) <= 6 or s == ""), "%P")
+    entry_var = tk.StringVar()
+    entry = tk.Entry(
+        root,
+        textvariable=entry_var,
+        font=("monospace", 18),
+        justify="center",
+        validate="key",
+        validatecommand=vcmd,
+        width=8,
+    )
+    entry.pack(pady=(0, 12))
+    entry.focus_set()
+
+    btn_frame = tk.Frame(root)
+    btn_frame.pack()
+
+    pair_btn = tk.Button(
+        btn_frame,
+        text="Pair",
+        width=10,
+        state="disabled",
+        command=lambda: _submit(),
+    )
+    pair_btn.pack(side="left", padx=4)
+
+    cancel_btn = tk.Button(
+        btn_frame,
+        text="Cancel",
+        width=10,
+        command=root.destroy,
+    )
+    cancel_btn.pack(side="left", padx=4)
+
+    def _on_change(*_: object) -> None:
+        state = "normal" if len(entry_var.get()) == 6 else "disabled"
+        pair_btn.configure(state=state)
+
+    entry_var.trace_add("write", _on_change)
+
+    def _submit() -> None:
+        nonlocal code
+        code = entry_var.get()
+        root.destroy()
+
+    # Enter key submits when 6 digits present
+    root.bind("<Return>", lambda _: _submit() if len(entry_var.get()) == 6 else None)
+
+    root.mainloop()
+    return code

--- a/apps/autohelper/autohelper/modules/config/router.py
+++ b/apps/autohelper/autohelper/modules/config/router.py
@@ -55,4 +55,14 @@ async def put_config(body: dict[str, Any]) -> dict[str, Any]:
     except Exception as exc:
         logger.warning("Failed to reinit mail service after config change: %s", exc)
 
+    # Reinitialise context service so autoart_session_id and other
+    # context-layer settings take effect without a restart.
+    try:
+        from autohelper.modules.context.service import ContextService
+
+        ctx = ContextService()
+        ctx.reinit_clients()
+    except Exception as exc:
+        logger.warning("Failed to reinit context service after config change: %s", exc)
+
     return current


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #326**
  * **PR #327**
    * **PR #328**
      * **PR #329** 👈
        * **PR #330**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Add tray pairing UI and ensure context settings apply immediately

### What Changed
- Tray menu now shows service status and pairing state, and includes a "Pair with AutoArt" action when not paired
- Selecting "Pair with AutoArt" opens a modal 6-digit code dialog (falls back to opening settings in a headless environment); successful pairing saves a session ID, updates the menu to "Paired", and initializes the paired client
- Pairing failures show a user-facing error dialog (or console message if dialogs are unavailable)
- Changing config now reinitializes the context service so session and other context-layer settings take effect without restarting the app

### Impact
`✅ Can pair from system tray without restarting`
`✅ Clearer pairing failure messages`
`✅ Context-layer settings take effect immediately after config changes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
