### PR TITLE
fix: restore migration 036 stub + wrap seeds in transaction

### DIFF
--- a/backend/src/db/migrations/036_action_type_definitions.ts
+++ b/backend/src/db/migrations/036_action_type_definitions.ts
@@ -1,0 +1,7 @@
+import { Kysely } from 'kysely';
+
+// Stub: original migration created action_type_definitions table.
+// Table was dropped in migration 049. This file exists to satisfy
+// Kysely's migration integrity check.
+export async function up(_db: Kysely<any>): Promise<void> {}
+export async function down(_db: Kysely<any>): Promise<void> {}


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #331** 👈
  * **PR #332**
    * **PR #333**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Restore migration stub and run record-definition seeds inside a transaction

### What Changed
- Adds a no-op migration file so migration integrity checks no longer fail due to a missing migration stub
- Wraps the record-definitions seeding in a single database transaction so all inserts/updates run together instead of partially applying on error
- Keeps seeding idempotent (lookup by name) and preserves the linking of Subtask → Task parent definition

### Impact
`✅ Migration integrity checks pass`
`✅ Fewer partial seeds and dangling records after seed failures`
`✅ Lower risk of inconsistent record-definition state during deploys`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
