### PR TITLE
fix: migrate Menu to --ws-* tokens, add glassmorphism to dropdowns

### DIFF
--- a/packages/ui/src/atoms/Dropdown.tsx
+++ b/packages/ui/src/atoms/Dropdown.tsx
@@ -22,7 +22,7 @@ export function DropdownContent({ children, className, sideOffset = 5, align = '
         <DropdownMenu.Portal>
             <DropdownMenu.Content
                 className={clsx(
-                    "z-50 min-w-[8rem] overflow-hidden rounded-md border border-[var(--ws-panel-border,#e2e8f0)] bg-[var(--ws-panel-bg,#fff)] p-1 font-sans text-[var(--ws-fg,#1e293b)] shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+                    "z-50 min-w-[8rem] overflow-hidden rounded-md border border-[var(--ws-panel-border,#e2e8f0)] bg-[var(--ws-panel-bg,#fff)]/90 backdrop-blur-sm p-1 font-sans text-[var(--ws-fg,#1e293b)] shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
                     className
                 )}
                 sideOffset={sideOffset}

--- a/packages/ui/src/molecules/Menu.tsx
+++ b/packages/ui/src/molecules/Menu.tsx
@@ -55,7 +55,7 @@ function MenuDropdown({
         <DropdownMenu.Portal>
             <DropdownMenu.Content
                 className={clsx(
-                    'z-50 min-w-[160px] py-1 bg-white rounded-lg border border-slate-200 shadow-lg font-sans',
+                    'z-50 min-w-[160px] py-1 bg-[var(--ws-panel-bg,#fff)]/90 backdrop-blur-sm rounded-lg border border-[var(--ws-panel-border,#e2e8f0)] shadow-lg font-sans',
                     'data-[state=open]:animate-in data-[state=closed]:animate-out',
                     'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
                     'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
@@ -114,15 +114,15 @@ function MenuItem<C extends ElementType = 'button'>({
                 {...rest}
                 className={clsx(
                     'w-full flex items-center gap-2 px-3 py-2 text-sm text-left transition-colors outline-none',
-                    'focus:bg-slate-100 cursor-pointer',
-                    'data-[disabled]:text-slate-400 data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none',
-                    !disabled && 'text-slate-700',
+                    'focus:bg-[var(--ws-row-expanded-bg,rgba(63,92,110,0.04))] cursor-pointer',
+                    'data-[disabled]:text-[var(--ws-text-disabled,#8c8c88)] data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none',
+                    !disabled && 'text-[var(--ws-fg,#2e2e2c)]',
                     className
                 )}
             >
                 {leftSection && <span className="flex-shrink-0">{leftSection}</span>}
                 <span className="flex-1">{children}</span>
-                {rightSection && <span className="flex-shrink-0 text-slate-400">{rightSection}</span>}
+                {rightSection && <span className="flex-shrink-0 text-[var(--ws-text-disabled,#8c8c88)]">{rightSection}</span>}
             </Component>
         </DropdownMenu.Item>
     );
@@ -137,7 +137,7 @@ function MenuLabel({ children, className }: MenuLabelProps) {
     return (
         <DropdownMenu.Label
             className={clsx(
-                'px-3 py-1.5 text-xs font-medium text-slate-500 uppercase tracking-wider',
+                'px-3 py-1.5 text-xs font-medium text-[var(--ws-text-secondary,#5a5a57)] uppercase tracking-wider',
                 className
             )}
         >
@@ -151,7 +151,7 @@ export interface MenuDividerProps {
 }
 
 function MenuDivider({ className }: MenuDividerProps) {
-    return <DropdownMenu.Separator className={clsx('my-1 h-px bg-slate-200', className)} />;
+    return <DropdownMenu.Separator className={clsx('my-1 h-px bg-[var(--ws-panel-border,#e2e8f0)]', className)} />;
 }
 
 // ---------------------------------------------------------------------------
@@ -185,16 +185,16 @@ function MenuSubTrigger({ children, leftSection, className, disabled }: MenuSubT
             disabled={disabled}
             className={clsx(
                 'w-full flex items-center gap-2 px-3 py-2 text-sm text-left transition-colors outline-none',
-                'focus:bg-slate-100 cursor-pointer',
-                'data-[state=open]:bg-slate-100',
-                'data-[disabled]:text-slate-400 data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none',
-                !disabled && 'text-slate-700',
+                'focus:bg-[var(--ws-row-expanded-bg,rgba(63,92,110,0.04))] cursor-pointer',
+                'data-[state=open]:bg-[var(--ws-row-expanded-bg,rgba(63,92,110,0.04))]',
+                'data-[disabled]:text-[var(--ws-text-disabled,#8c8c88)] data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none',
+                !disabled && 'text-[var(--ws-fg,#2e2e2c)]',
                 className
             )}
         >
             {leftSection && <span className="flex-shrink-0">{leftSection}</span>}
             <span className="flex-1">{children}</span>
-            <ChevronRight size={14} className="flex-shrink-0 text-slate-400" />
+            <ChevronRight size={14} className="flex-shrink-0 text-[var(--ws-text-disabled,#8c8c88)]" />
         </DropdownMenu.SubTrigger>
     );
 }
@@ -211,7 +211,7 @@ function MenuSubContent({ children, className, sideOffset = 2, alignOffset = -5 
         <DropdownMenu.Portal>
             <DropdownMenu.SubContent
                 className={clsx(
-                    'z-50 min-w-[160px] py-1 bg-white rounded-lg border border-slate-200 shadow-lg font-sans',
+                    'z-50 min-w-[160px] py-1 bg-[var(--ws-panel-bg,#fff)]/90 backdrop-blur-sm rounded-lg border border-[var(--ws-panel-border,#e2e8f0)] shadow-lg font-sans',
                     'data-[state=open]:animate-in data-[state=closed]:animate-out',
                     'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
                     'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #337** 👈
  * **PR #338**
    * **PR #339**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Migrate Menu and Dropdown visuals to theme tokens and add glassmorphism

### What Changed
- Dropdown and Menu panels now use theme color tokens for background and borders and render with a semi-transparent background plus backdrop blur (glassmorphism), so dropdowns appear translucent with a subtle blur.
- Text, disabled text, and focus/hover backgrounds for menu items and submenu triggers now use theme tokens, producing more consistent and readable colors across items (including the chevron and right-side labels).
- Menu separators and panel borders use the centralized panel-border token for consistent divider contrast.

### Impact
`✅ Consistent menu colors with theme tokens`
`✅ More readable disabled menu items`
`✅ Subtle glass-like dropdown appearance`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
