### PR TITLE
fix: add close button to SelectionInspector, migrate tab accents to tokens

### DIFF
--- a/frontend/src/ui/composites/SelectionInspector.tsx
+++ b/frontend/src/ui/composites/SelectionInspector.tsx
@@ -20,7 +20,7 @@
 
 import { useMemo } from 'react';
 import { clsx } from 'clsx';
-import { FileText, Link2, ExternalLink, Wrench, Lightbulb, Info, History, Tag, List, Plus, GitBranch, Map, Mail } from 'lucide-react';
+import { FileText, Link2, ExternalLink, Wrench, Lightbulb, Info, History, Tag, List, Plus, GitBranch, Map, Mail, X } from 'lucide-react';
 
 import { RecordPropertiesView } from './RecordPropertiesView';
 import { ImportItemDetailsView } from './ImportItemDetailsView';
@@ -79,6 +79,7 @@ export interface SelectionInspectorProps {
         selectedItemId: string | null;
         onSelectItem?: (id: string | null) => void;
     };
+    onClose?: () => void;
 }
 
 /**
@@ -98,7 +99,7 @@ function shouldAcceptSelection(selection: Selection, boundPanelIds: Set<string>)
     return false;
 }
 
-export function SelectionInspector({ importContext }: SelectionInspectorProps = {}) {
+export function SelectionInspector({ importContext, onClose }: SelectionInspectorProps = {}) {
     const { selection: globalSelection, inspectorTabMode, setInspectorMode, importPlan: globalPlan } = useUIStore();
     const collectionMode = useCollectionModeOptional();
     const boundPanelIds = useBoundPanelIds();
@@ -154,11 +155,22 @@ export function SelectionInspector({ importContext }: SelectionInspectorProps = 
             <div className="bg-ws-panel-bg flex flex-col h-full overflow-hidden">
                 <div className="h-10 border-b border-ws-panel-border flex items-center justify-between px-3 bg-ws-bg/50">
                     <span className="text-xs text-ws-muted">Select an item to inspect</span>
-                    {isBound && activeWorkspace && (
-                        <span className={clsx('text-[10px] font-medium px-1.5 py-0.5 rounded', colorClasses.bg100, colorClasses.text700)}>
-                            {activeWorkspace.label}
-                        </span>
-                    )}
+                    <div className="flex items-center">
+                        {isBound && activeWorkspace && (
+                            <span className={clsx('text-[10px] font-medium px-1.5 py-0.5 rounded', colorClasses.bg100, colorClasses.text700)}>
+                                {activeWorkspace.label}
+                            </span>
+                        )}
+                        {onClose && (
+                            <button
+                                onClick={onClose}
+                                className="ml-auto px-1.5 h-full flex items-center text-ws-muted hover:text-ws-text-secondary transition-colors"
+                                title="Close inspector"
+                            >
+                                <X size={14} />
+                            </button>
+                        )}
+                    </div>
                 </div>
                 <div className="flex-1 flex items-center justify-center text-xs text-ws-muted p-4 text-center">
                     <div>
@@ -168,7 +180,7 @@ export function SelectionInspector({ importContext }: SelectionInspectorProps = 
                                 : 'No selection'}
                         </p>
                         <p className="text-ws-muted">
-                            Press <kbd className="px-1 py-0.5 bg-slate-100 rounded text-ws-text-secondary">Ctrl+D</kbd> to quick declare
+                            Press <kbd className="px-1 py-0.5 bg-[var(--ws-row-expanded-bg,rgba(63,92,110,0.04))] rounded text-ws-text-secondary">Ctrl+D</kbd> to quick declare
                         </p>
                     </div>
                 </div>
@@ -306,7 +318,7 @@ export function SelectionInspector({ importContext }: SelectionInspectorProps = 
                             onClick={() => setInspectorMode(tab.id)}
                             className={clsx(
                                 'flex-1 h-full flex items-center justify-center gap-1.5 text-xs font-medium transition-all relative',
-                                isActive ? 'text-blue-600' : 'text-ws-muted hover:text-ws-text-secondary'
+                                isActive ? 'text-[var(--ws-accent,#3F5C6E)]' : 'text-ws-muted hover:text-ws-text-secondary'
                             )}
                             data-aa-component="SelectionInspector"
                             data-aa-id={`tab-${tab.id}`}
@@ -315,7 +327,7 @@ export function SelectionInspector({ importContext }: SelectionInspectorProps = 
                             <Icon size={14} />
                             <span>{tab.label}</span>
                             {isActive && (
-                                <div className="absolute bottom-0 left-2 right-2 h-0.5 bg-blue-600 rounded-t" />
+                                <div className="absolute bottom-0 left-2 right-2 h-0.5 bg-[var(--ws-accent,#3F5C6E)] rounded-t" />
                             )}
                         </button>
                     );
@@ -344,6 +356,20 @@ export function SelectionInspector({ importContext }: SelectionInspectorProps = 
                     >
                         <Plus size={12} />
                         {collectionMode.isInCollection(inspectedItem.id) ? 'Added' : 'Add'}
+                    </button>
+                )}
+
+                {/* Close button */}
+                {onClose && (
+                    <button
+                        onClick={onClose}
+                        className={clsx(
+                            'px-1.5 h-full flex items-center text-ws-muted hover:text-ws-text-secondary transition-colors',
+                            collectionMode?.isCollecting && inspectedItem ? 'ml-1' : 'ml-auto'
+                        )}
+                        title="Close inspector"
+                    >
+                        <X size={14} />
                     </button>
                 )}
             </div>

--- a/frontend/src/ui/layout/MainLayout.tsx
+++ b/frontend/src/ui/layout/MainLayout.tsx
@@ -273,10 +273,21 @@ function CenterWorkspacePanel(props: IDockviewPanelProps) {
 
 function SelectionInspectorPanel(props: IDockviewPanelProps) {
   const importContext = useImportContextOptional();
+  const { closePanel } = useWorkspaceStore();
+
+  const handleClose = useCallback(() => {
+    const panelId = props.api.id;
+    if (panelId === 'selection-inspector') {
+      closePanel('selection-inspector');
+    } else {
+      props.api.close();
+    }
+  }, [props.api, closePanel]);
 
   return (
     <div className="h-full overflow-auto bg-ws-panel-bg relative group">
       <SelectionInspector
+        onClose={handleClose}
         importContext={importContext ? {
           plan: importContext.plan,
           selectedItemId: importContext.selectedItemId,


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #337**
  * **PR #338** 👈
    * **PR #339**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Add a close button to the Selection inspector and use design token for tab accents

### What Changed
- The inspector header now shows a Close button when a close handler is provided; a Close button also appears in the tab header area while inspecting items. Clicking it closes the inspector panel.
- Active tab text color and the active-tab underline now use a CSS token (skin accent) instead of a hard-coded blue, making tab accents follow the app theme.
- The empty-state keyboard hint background was updated to use the panel token; the workspace label and header layout were slightly adjusted to keep controls aligned.

### Impact
`✅ Easier closing of inspector panels`
`✅ Consistent tab accent across themes`
`✅ Clearer empty-state controls and keyboard hint`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
