### PR TITLE
feat: AutoHelper triage endpoints

### DIFF
--- a/apps/autohelper/autohelper/db/migrations/0006_mail_triage.sql
+++ b/apps/autohelper/autohelper/db/migrations/0006_mail_triage.sql
@@ -1,0 +1,6 @@
+-- Migration: 0006_mail_triage.sql
+-- Description: Add triage columns to transient_emails for manual triage workflow
+
+ALTER TABLE transient_emails ADD COLUMN triage_status TEXT DEFAULT 'pending';
+ALTER TABLE transient_emails ADD COLUMN triage_notes TEXT;
+ALTER TABLE transient_emails ADD COLUMN triaged_at DATETIME;

--- a/apps/autohelper/autohelper/modules/mail/__init__.py
+++ b/apps/autohelper/autohelper/modules/mail/__init__.py
@@ -7,6 +7,8 @@ from .schemas import (
     MailServiceStatus,
     TransientEmail,
     TransientEmailList,
+    TriageRequest,
+    TriageResponse,
 )
 from .service import MailService
 
@@ -20,4 +22,6 @@ __all__ = [
     "IngestionLogList",
     "IngestRequest",
     "IngestResponse",
+    "TriageRequest",
+    "TriageResponse",
 ]

--- a/apps/autohelper/autohelper/modules/mail/schemas.py
+++ b/apps/autohelper/autohelper/modules/mail/schemas.py
@@ -39,6 +39,9 @@ class TransientEmail(BaseModel):
     metadata: dict[str, Any] | None = None
     ingestion_id: int | None = None
     created_at: datetime | None = None
+    triage_status: str | None = "pending"
+    triage_notes: str | None = None
+    triaged_at: datetime | None = None
 
 
 class TransientEmailList(BaseModel):
@@ -71,6 +74,32 @@ class IngestionLogList(BaseModel):
 
     entries: list[IngestionLogEntry]
     total: int
+
+
+# =============================================================================
+# TRIAGE
+# =============================================================================
+
+
+class TriageRequest(BaseModel):
+    """Request to update triage status of an email."""
+
+    status: str  # 'pending' | 'action_required' | 'informational' | 'archived'
+    notes: str | None = None
+
+
+class TriageResponse(BaseModel):
+    """Response from triage operation."""
+
+    status: str
+    email_id: str
+    triage_status: str
+    triaged_at: str | None
+
+
+# =============================================================================
+# INGESTION
+# =============================================================================
 
 
 class IngestRequest(BaseModel):

--- a/frontend/src/api/types/mail.ts
+++ b/frontend/src/api/types/mail.ts
@@ -12,6 +12,9 @@ export interface TransientEmail {
   metadata: Record<string, unknown> | null;
   ingestion_id: number | null;
   created_at: string | null;
+  triage_status: TriageStatus | null;
+  triage_notes: string | null;
+  triaged_at: string | null;
 }
 
 export interface TransientEmailList {

--- a/frontend/src/lib/dataAdapter.ts
+++ b/frontend/src/lib/dataAdapter.ts
@@ -53,9 +53,19 @@ function inferPriority(email: TransientEmail): Priority {
 /**
  * Create placeholder triage info for emails without enrichment
  */
-function createPlaceholderTriage(): TriageInfo {
+function createPlaceholderTriage(email?: TransientEmail): TriageInfo {
+  // Use real triage_status from the backend when available
+  if (email?.triage_status && email.triage_status !== 'pending') {
+    return {
+      status: email.triage_status,
+      confidence: 1,
+      reasoning: email.triage_notes ?? null,
+      suggestedAction: null,
+    };
+  }
+
   return {
-    status: 'pending',
+    status: email?.triage_status ?? 'pending',
     confidence: 0,
     reasoning: null,
     suggestedAction: null,
@@ -74,7 +84,7 @@ export function adaptTransientEmail(email: TransientEmail): ProcessedEmail {
     receivedAt: email.received_at ? new Date(email.received_at) : null,
     projectId: email.project_id,
     bodyPreview: email.body_preview || '',
-    triage: createPlaceholderTriage(),
+    triage: createPlaceholderTriage(email),
     priority: inferPriority(email),
     priorityFactors: [],
     extractedKeywords: [],


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #341**
  * **PR #342**
    * **PR #343**
      * **PR #344**
        * **PR #345**
          * **PR #346** 👈
            * **PR #348**
              * **PR #347**
                * **PR #349**
                  * **PR #350**
                    * **PR #351**
                      * **PR #352**
                        * **PR #353**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Add manual triage fields and API endpoints for email records

### What Changed
- Transient emails now include triage fields (status, notes, triaged timestamp) in API responses and frontend types so triage state is visible to clients
- New triage API endpoints let clients set or update triage status and notes, and provide shortcuts to archive, mark "action required", or mark "informational"
- Frontend adapts use backend triage state when present so emails show stored triage status instead of always defaulting to "pending"
- Database migration adds persisted triage columns so notes and status survive restarts

### Impact
`✅ Clearer email triage state in UI and API`
`✅ Can mark emails as action required or archived via API`
`✅ Triage notes persist and are surfaced to clients`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
