### PR TITLE
feat: body_html capture across AutoHelper, backend, and frontend

### DIFF
--- a/apps/autohelper/autohelper/db/migrations/0007_mail_body_html.sql
+++ b/apps/autohelper/autohelper/db/migrations/0007_mail_body_html.sql
@@ -1,0 +1,4 @@
+-- Migration: 0007_mail_body_html.sql
+-- Description: Add body_html column for storing full HTML email content
+
+ALTER TABLE transient_emails ADD COLUMN body_html TEXT;

--- a/apps/autohelper/autohelper/modules/mail/schemas.py
+++ b/apps/autohelper/autohelper/modules/mail/schemas.py
@@ -36,6 +36,7 @@ class TransientEmail(BaseModel):
     received_at: datetime | None
     project_id: str | None
     body_preview: str | None
+    body_html: str | None = None
     metadata: dict[str, Any] | None = None
     ingestion_id: int | None = None
     created_at: datetime | None = None

--- a/apps/autohelper/autohelper/modules/mail/service.py
+++ b/apps/autohelper/autohelper/modules/mail/service.py
@@ -402,6 +402,7 @@ class MailService:
         subject = getattr(item, "Subject", "")
         sender = getattr(item, "SenderEmailAddress", "")
         body = getattr(item, "Body", "")[:500]  # Preview
+        body_html = getattr(item, "HTMLBody", None)
 
         metadata = {
             "importance": getattr(item, "Importance", 1),
@@ -411,10 +412,10 @@ class MailService:
         db.execute(
             """
             INSERT OR IGNORE INTO transient_emails
-                (id, subject, sender, received_at, project_id, body_preview, metadata)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+                (id, subject, sender, received_at, project_id, body_preview, body_html, metadata)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (entry_id, subject, sender, received_dt, project_id, body, json.dumps(metadata)),
+            (entry_id, subject, sender, received_dt, project_id, body, body_html, json.dumps(metadata)),
         )
         db.commit()
 

--- a/backend/src/db/migrations/053_mail_body_html.ts
+++ b/backend/src/db/migrations/053_mail_body_html.ts
@@ -1,0 +1,22 @@
+/**
+ * Migration 053: Add body_html to mail_messages
+ *
+ * Stores the full HTML body of promoted emails. Can be large (10-100KB),
+ * stored as TEXT without truncation to support faithful rendering.
+ */
+
+import { Kysely } from 'kysely';
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+    await db.schema
+        .alterTable('mail_messages')
+        .addColumn('body_html', 'text')
+        .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+    await db.schema
+        .alterTable('mail_messages')
+        .dropColumn('body_html')
+        .execute();
+}

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -648,6 +648,7 @@ export interface MailMessagesTable {
   sender_name: string | null;
   received_at: Date | null;
   body_preview: string | null;
+  body_html: string | null;
   metadata: Generated<unknown>; // JSONB
   project_id: string | null;
   promoted_at: Generated<Date>;

--- a/backend/src/modules/mail/mail.service.ts
+++ b/backend/src/modules/mail/mail.service.ts
@@ -24,6 +24,7 @@ interface AutoHelperEmail {
   received_at: string | null;
   project_id: string | null;
   body_preview: string | null;
+  body_html: string | null;
   metadata: Record<string, unknown> | null;
 }
 
@@ -109,6 +110,7 @@ export async function promoteEmail(
       sender_name: extractSenderName(email.sender),
       received_at: email.received_at ? new Date(email.received_at) : null,
       body_preview: email.body_preview,
+      body_html: email.body_html ?? null,
       metadata: email.metadata ?? {},
       project_id: email.project_id ?? null,
       promoted_by: promotedBy,
@@ -249,6 +251,7 @@ export async function getLinksForTarget(
       'mail_messages.sender_name',
       'mail_messages.received_at',
       'mail_messages.body_preview',
+      'mail_messages.body_html',
       'mail_messages.metadata',
       'mail_messages.project_id',
       'mail_messages.promoted_at',
@@ -275,6 +278,7 @@ export async function getLinksForTarget(
       sender_name: row.sender_name,
       received_at: row.received_at,
       body_preview: row.body_preview,
+      body_html: row.body_html,
       metadata: row.metadata,
       project_id: row.project_id,
       promoted_at: row.promoted_at,

--- a/frontend/src/api/types/mail.ts
+++ b/frontend/src/api/types/mail.ts
@@ -128,6 +128,7 @@ export interface MailMessage {
   sender_name: string | null;
   received_at: string | null;
   body_preview: string | null;
+  body_html: string | null;
   metadata: Record<string, unknown>;
   project_id: string | null;
   promoted_at: string;


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #341**
  * **PR #342**
    * **PR #343**
      * **PR #344**
        * **PR #345**
          * **PR #346**
            * **PR #348**
              * **PR #347**
                * **PR #349**
                  * **PR #350**
                    * **PR #351** 👈
                      * **PR #352**
                        * **PR #353**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Capture and surface full HTML email body for promoted and transient emails

### What Changed
- Promoted emails now store a new body_html field in the database so the full HTML body is preserved when an email is promoted.
- API and frontend types now include body_html so clients receive the full HTML content for mail messages returned by endpoints (including link queries).
- AutoHelper ingestion now saves HTMLBody into transient email records and the transient_emails table schema has a body_html column; database migrations add/remove the new column.

### Impact
`✅ Full HTML in promoted emails`
`✅ Full HTML available to frontend/API responses`
`✅ Preserved HTML during AutoHelper ingestion`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
