### PR TITLE
fix: type theme registry list() as readonly to prevent cache mutation

### DIFF
--- a/frontend/src/workspace/themes/components/ThemePicker.tsx
+++ b/frontend/src/workspace/themes/components/ThemePicker.tsx
@@ -19,6 +19,7 @@ import {
   useWorkspaceThemeId,
   setWorkspaceTheme,
 } from '../useWorkspaceTheme';
+import type { WorkspaceThemeModule } from '../types';
 
 export function ThemePicker() {
   const themes = useAvailableThemes();
@@ -31,7 +32,7 @@ export function ThemePicker() {
       acc[variant].push(theme);
       return acc;
     },
-    {} as Record<string, typeof themes>
+    {} as Record<string, WorkspaceThemeModule[]>
   );
 
   return (

--- a/frontend/src/workspace/themes/registry.ts
+++ b/frontend/src/workspace/themes/registry.ts
@@ -42,7 +42,7 @@ class ThemeRegistryImpl implements WorkspaceThemeRegistry {
     return this.themes.get(id);
   }
 
-  list(): WorkspaceThemeModule[] {
+  list(): readonly WorkspaceThemeModule[] {
     return (this.cachedList ??= Array.from(this.themes.values()));
   }
 

--- a/frontend/src/workspace/themes/types.ts
+++ b/frontend/src/workspace/themes/types.ts
@@ -123,7 +123,7 @@ export interface WorkspaceThemeRegistry {
   get(id: WorkspaceThemeId): WorkspaceThemeModule | undefined;
 
   /** List all registered themes */
-  list(): WorkspaceThemeModule[];
+  list(): readonly WorkspaceThemeModule[];
 
   /** Get themes by density */
   getByDensity(density: ThemeDensity): WorkspaceThemeModule[];

--- a/frontend/src/workspace/themes/useWorkspaceTheme.ts
+++ b/frontend/src/workspace/themes/useWorkspaceTheme.ts
@@ -106,7 +106,7 @@ export function useWorkspaceTheme(): WorkspaceThemeModule | undefined {
 /**
  * Get all available themes
  */
-export function useAvailableThemes(): WorkspaceThemeModule[] {
+export function useAvailableThemes(): readonly WorkspaceThemeModule[] {
   return useSyncExternalStore(
     (cb) => workspaceThemeRegistry.subscribe(cb),
     () => workspaceThemeRegistry.list(),


### PR DESCRIPTION
## **CodeAnt-AI Description**
Prevent accidental modification of the theme registry list by exposing it as read-only

### What Changed
- The registry now returns a read-only list of themes so callers cannot mutate the cached list
- Theme-related APIs and the theme picker now expose the list as read-only, preventing accidental in-place changes
- Consumers of available themes via the hook receive an immutable list, preserving registry cache integrity

### Impact
`✅ Fewer theme cache corruption issues`
`✅ Reduced runtime errors from accidental array mutations`
`✅ Safer theme selection UI behavior`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #354** 👈
  * **PR #355**
    * **PR #356**
      * **PR #357**
        * **PR #358**
          * **PR #359**
            * **PR #360**
              * **PR #361**
                * **PR #362**
                  * **PR #363**
                    * **PR #364**
                      * **PR #365**
                        * **PR #366**
                          * **PR #368**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->