### PR TITLE
fix: propagate specific pairing errors from AutoHelper to frontend

### DIFF
--- a/apps/autohelper/autohelper/modules/pairing/router.py
+++ b/apps/autohelper/autohelper/modules/pairing/router.py
@@ -44,10 +44,10 @@ def pair(body: PairRequest) -> PairResponse:
         )
 
         hostname = socket.gethostname()
-        session_id = client.pair_with_code(body.code, instance_name=hostname)
+        session_id, error = client.pair_with_code(body.code, instance_name=hostname)
 
         if not session_id:
-            return PairResponse(paired=False, error="Handshake failed — check the code and try again")
+            return PairResponse(paired=False, error=error or "Handshake failed — check the code and try again")
 
         # Persist to config.json
         store = ConfigStore()

--- a/frontend/src/pages/settings/AutoHelperSection.tsx
+++ b/frontend/src/pages/settings/AutoHelperSection.tsx
@@ -29,6 +29,7 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 
+import { RequestTimeoutError } from '../../api/autohelperClient';
 import { useAutoHelperInstances, useDisconnectAutoHelper, useGeneratePairingCode } from '../../api/connections';
 import {
     useAutoHelperHealth,
@@ -164,7 +165,9 @@ function PairCard({ autohelperStatus }: { autohelperStatus: { connected: boolean
                 setError(result.error ?? 'Pairing failed');
             }
         } catch (err) {
-            const msg = err instanceof Error ? err.message : 'Pairing failed — is AutoHelper running?';
+            const msg = err instanceof RequestTimeoutError
+                ? 'AutoHelper not responding — is it running?'
+                : err instanceof Error ? err.message : 'Pairing failed';
             setError(msg);
             toast.error(msg);
         }


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #354**
  * **PR #355**
    * **PR #356** 👈
      * **PR #357**
        * **PR #358**
          * **PR #359**
            * **PR #360**
              * **PR #361**
                * **PR #362**
                  * **PR #363**
                    * **PR #364**
                      * **PR #365**
                        * **PR #366**
                          * **PR #368**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Propagate specific AutoHelper pairing errors to the frontend

### What Changed
- Pairing failures now surface the exact reason to the user instead of a generic failure: backend returns specific messages like "Backend unreachable", "Backend timed out", or any error text returned by the backend.
- Frontend shows a clear, targeted message when the AutoHelper service doesn't respond: "AutoHelper not responding — is it running?" for request timeouts.
- Backend persists successful sessions as before; when pairing fails the UI receives the backend-provided error string so users see actionable feedback.

### Impact
`✅ Clearer pairing errors`
`✅ Fewer incorrect retry attempts`
`✅ Shorter troubleshooting time`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
