### PR TITLE
fix: use theme classes for dropdown backgrounds instead of arbitrary var() values

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,7 +2,7 @@
 @import "./workspace/themes/variables.css";
 
 /* Include @autoart/ui package to ensure its Tailwind classes aren't purged */
-@source "../packages/ui/src";
+@source "../../packages/ui/src";
 
 @theme {
   /* Custom colors for record types */

--- a/packages/ui/src/atoms/Dropdown.tsx
+++ b/packages/ui/src/atoms/Dropdown.tsx
@@ -22,7 +22,7 @@ export function DropdownContent({ children, className, sideOffset = 5, align = '
         <DropdownMenu.Portal>
             <DropdownMenu.Content
                 className={clsx(
-                    "z-50 min-w-[8rem] overflow-hidden rounded-md border border-[var(--ws-panel-border,#e2e8f0)] bg-[var(--ws-panel-bg,#fff)] p-1 font-sans text-[var(--ws-fg,#1e293b)] shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+                    "z-50 min-w-[8rem] overflow-hidden rounded-md border border-ws-panel-border bg-ws-panel-bg p-1 font-sans text-ws-fg shadow-md",
                     className
                 )}
                 sideOffset={sideOffset}
@@ -48,7 +48,7 @@ export function DropdownItem({ children, onSelect, className, disabled }: Dropdo
             onSelect={onSelect}
             disabled={disabled}
             className={clsx(
-                "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm font-sans outline-none transition-colors focus:bg-[var(--ws-row-expanded-bg,rgba(63,92,110,0.04))] focus:text-[var(--ws-fg,#1e293b)] data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+                "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm font-sans outline-none transition-colors focus:bg-ws-row-expanded-bg focus:text-ws-fg data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
                 className
             )}
         >
@@ -59,14 +59,14 @@ export function DropdownItem({ children, onSelect, className, disabled }: Dropdo
 
 export function DropdownLabel({ children, className }: { children: ReactNode, className?: string }) {
     return (
-        <DropdownMenu.Label className={clsx("px-2 py-1.5 text-xs font-sans font-semibold text-[var(--ws-text-secondary,#5a5a57)]", className)}>
+        <DropdownMenu.Label className={clsx("px-2 py-1.5 text-xs font-sans font-semibold text-ws-text-secondary", className)}>
             {children}
         </DropdownMenu.Label>
     );
 }
 
 export function DropdownSeparator({ className }: { className?: string }) {
-    return <DropdownMenu.Separator className={clsx("-mx-1 my-1 h-px bg-[var(--ws-panel-border,#e2e8f0)]", className)} />;
+    return <DropdownMenu.Separator className={clsx("-mx-1 my-1 h-px bg-ws-panel-border", className)} />;
 }
 
 interface DropdownCheckboxItemProps {
@@ -85,7 +85,7 @@ export function DropdownCheckboxItem({ children, checked, onCheckedChange, class
             onSelect={(e) => e.preventDefault()}
             disabled={disabled}
             className={clsx(
-                "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm font-sans outline-none transition-colors focus:bg-[var(--ws-row-expanded-bg,rgba(63,92,110,0.04))] focus:text-[var(--ws-fg,#1e293b)] data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+                "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm font-sans outline-none transition-colors focus:bg-ws-row-expanded-bg focus:text-ws-fg data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
                 className
             )}
         >

--- a/packages/ui/src/molecules/Menu.tsx
+++ b/packages/ui/src/molecules/Menu.tsx
@@ -55,14 +55,7 @@ function MenuDropdown({
         <DropdownMenu.Portal>
             <DropdownMenu.Content
                 className={clsx(
-                    'z-50 min-w-[160px] py-1 bg-[var(--ws-panel-bg,#fff)] rounded-lg border border-[var(--ws-panel-border,#e2e8f0)] shadow-lg font-sans',
-                    'data-[state=open]:animate-in data-[state=closed]:animate-out',
-                    'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-                    'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-                    'data-[side=bottom]:slide-in-from-top-2',
-                    'data-[side=left]:slide-in-from-right-2',
-                    'data-[side=right]:slide-in-from-left-2',
-                    'data-[side=top]:slide-in-from-bottom-2',
+                    'z-50 min-w-[160px] py-1 bg-ws-panel-bg rounded-lg border border-ws-panel-border shadow-lg font-sans',
                     className
                 )}
                 align={align}
@@ -114,15 +107,15 @@ function MenuItem<C extends ElementType = 'button'>({
                 {...rest}
                 className={clsx(
                     'w-full flex items-center gap-2 px-3 py-2 text-sm text-left transition-colors outline-none',
-                    'focus:bg-[var(--ws-row-expanded-bg,rgba(63,92,110,0.04))] cursor-pointer',
-                    'data-[disabled]:text-[var(--ws-text-disabled,#8c8c88)] data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none',
-                    !disabled && 'text-[var(--ws-fg,#2e2e2c)]',
+                    'focus:bg-ws-row-expanded-bg cursor-pointer',
+                    'data-[disabled]:text-ws-text-disabled data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none',
+                    !disabled && 'text-ws-fg',
                     className
                 )}
             >
                 {leftSection && <span className="flex-shrink-0">{leftSection}</span>}
                 <span className="flex-1">{children}</span>
-                {rightSection && <span className="flex-shrink-0 text-[var(--ws-text-disabled,#8c8c88)]">{rightSection}</span>}
+                {rightSection && <span className="flex-shrink-0 text-ws-text-disabled">{rightSection}</span>}
             </Component>
         </DropdownMenu.Item>
     );
@@ -137,7 +130,7 @@ function MenuLabel({ children, className }: MenuLabelProps) {
     return (
         <DropdownMenu.Label
             className={clsx(
-                'px-3 py-1.5 text-xs font-medium text-[var(--ws-text-secondary,#5a5a57)] uppercase tracking-wider',
+                'px-3 py-1.5 text-xs font-medium text-ws-text-secondary uppercase tracking-wider',
                 className
             )}
         >
@@ -151,7 +144,7 @@ export interface MenuDividerProps {
 }
 
 function MenuDivider({ className }: MenuDividerProps) {
-    return <DropdownMenu.Separator className={clsx('my-1 h-px bg-[var(--ws-panel-border,#e2e8f0)]', className)} />;
+    return <DropdownMenu.Separator className={clsx('my-1 h-px bg-ws-panel-border', className)} />;
 }
 
 // ---------------------------------------------------------------------------
@@ -185,16 +178,16 @@ function MenuSubTrigger({ children, leftSection, className, disabled }: MenuSubT
             disabled={disabled}
             className={clsx(
                 'w-full flex items-center gap-2 px-3 py-2 text-sm text-left transition-colors outline-none',
-                'focus:bg-[var(--ws-row-expanded-bg,rgba(63,92,110,0.04))] cursor-pointer',
-                'data-[state=open]:bg-[var(--ws-row-expanded-bg,rgba(63,92,110,0.04))]',
-                'data-[disabled]:text-[var(--ws-text-disabled,#8c8c88)] data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none',
-                !disabled && 'text-[var(--ws-fg,#2e2e2c)]',
+                'focus:bg-ws-row-expanded-bg cursor-pointer',
+                'data-[state=open]:bg-ws-row-expanded-bg',
+                'data-[disabled]:text-ws-text-disabled data-[disabled]:cursor-not-allowed data-[disabled]:pointer-events-none',
+                !disabled && 'text-ws-fg',
                 className
             )}
         >
             {leftSection && <span className="flex-shrink-0">{leftSection}</span>}
             <span className="flex-1">{children}</span>
-            <ChevronRight size={14} className="flex-shrink-0 text-[var(--ws-text-disabled,#8c8c88)]" />
+            <ChevronRight size={14} className="flex-shrink-0 text-ws-text-disabled" />
         </DropdownMenu.SubTrigger>
     );
 }
@@ -211,14 +204,7 @@ function MenuSubContent({ children, className, sideOffset = 2, alignOffset = -5 
         <DropdownMenu.Portal>
             <DropdownMenu.SubContent
                 className={clsx(
-                    'z-50 min-w-[160px] py-1 bg-[var(--ws-panel-bg,#fff)] rounded-lg border border-[var(--ws-panel-border,#e2e8f0)] shadow-lg font-sans',
-                    'data-[state=open]:animate-in data-[state=closed]:animate-out',
-                    'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-                    'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-                    'data-[side=bottom]:slide-in-from-top-2',
-                    'data-[side=left]:slide-in-from-right-2',
-                    'data-[side=right]:slide-in-from-left-2',
-                    'data-[side=top]:slide-in-from-bottom-2',
+                    'z-50 min-w-[160px] py-1 bg-ws-panel-bg rounded-lg border border-ws-panel-border shadow-lg font-sans',
                     className
                 )}
                 sideOffset={sideOffset}


### PR DESCRIPTION
## **User description**
Tailwind v4's oklch color pipeline breaks arbitrary-value CSS variables
in bg-[var(--ws-panel-bg,#fff)] — the computed background-color ends up
transparent. The @theme block already registers these as proper theme
values, so migrate Menu and Dropdown to first-class classes like
bg-ws-panel-bg.

Also fixes @source path (pointed at nonexistent frontend/packages/ui/src)
and removes dead tailwindcss-animate classes (package not installed).

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #354**
  * **PR #355**
    * **PR #356**
      * **PR #357** 👈
        * **PR #358**
          * **PR #359**
            * **PR #360**
              * **PR #361**
                * **PR #362**
                  * **PR #363**
                    * **PR #364**
                      * **PR #365**
                        * **PR #366**
                          * **PR #368**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Use theme color classes for dropdowns and menus so colors render correctly

### What Changed
- Dropdowns, menu items, labels, separators and submenu panels now use theme class names for background, border and text (e.g., bg-ws-panel-bg, border-ws-panel-border, text-ws-fg) instead of arbitrary CSS variable expressions.
- Focus and disabled states now use theme classes (e.g., focus:bg-ws-row-expanded-bg, text-ws-text-disabled) so hover/focus/disabled colors apply reliably.
- Fixed the local CSS source path to include the UI package so its Tailwind classes are retained during build.

### Impact
`✅ Dropdown and menu backgrounds no longer render transparent`
`✅ Focus and disabled menu item colors now display correctly`
`✅ UI package classes preserved in build to prevent missing styles`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
