### PR TITLE
fix: spawn project-panel from header Projects button

### DIFF
--- a/frontend/src/ui/layout/Header.tsx
+++ b/frontend/src/ui/layout/Header.tsx
@@ -73,6 +73,7 @@ export function Header() {
 
   // Active state derived from open panels - memoized to prevent re-computation
   const panelStates = useMemo(() => {
+    const isProjectActive = openPanelIds.includes('project-panel');
     const isRecordsActive = openPanelIds.includes('records-list');
     const isFieldsActive = openPanelIds.includes('fields-list');
     const isActionsActive = openPanelIds.includes('actions-list');
@@ -83,6 +84,7 @@ export function Header() {
     const isIntakeActive = openPanelIds.includes('intake-workbench');
 
     return {
+      isProjectActive,
       isRecordsActive,
       isFieldsActive,
       isActionsActive,
@@ -97,6 +99,7 @@ export function Header() {
   }, [openPanelIds]);
 
   const {
+    isProjectActive,
     isRecordsActive,
     isFieldsActive,
     isActionsActive,
@@ -153,11 +156,11 @@ export function Header() {
 
           {/* Projects - primary navigation home */}
           <Button
-            variant={location.pathname === '/' ? 'light' : 'subtle'}
+            variant={isProjectActive ? 'light' : 'subtle'}
             color="gray"
             size="sm"
             leftSection={<LayoutGrid size={14} />}
-            onClick={() => { navigate('/'); setCenterContentType('projects'); }}
+            onClick={() => handleOpenPanel('project-panel')}
           >
             Projects
           </Button>


### PR DESCRIPTION
## **User description**
Projects button was routing to center content via setCenterContentType,
bypassing the dockview panel system entirely. Now uses handleOpenPanel
to spawn/focus the registered project-panel tab, consistent with how
every other header button works.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #354**
  * **PR #355**
    * **PR #356**
      * **PR #357**
        * **PR #358** 👈
          * **PR #359**
            * **PR #360**
              * **PR #361**
                * **PR #362**
                  * **PR #363**
                    * **PR #364**
                      * **PR #365**
                        * **PR #366**
                          * **PR #368**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
**Open and focus Projects panel from header button instead of routing**

### What Changed
- The Projects button in the header now opens or focuses the registered Projects panel instead of navigating to the root page and changing center content.
- The Projects button's active (highlighted) state is tied to whether the Projects panel is open, so it visually reflects panel focus correctly.
- Other header buttons keep using the same panel system, providing consistent behavior across header controls.

### Impact
`✅ Consistent panel focus from header`
`✅ Prevents unwanted route navigation when opening Projects`
`✅ Clearer active state for Projects button`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
