### PR TITLE
feat: strip session plumbing from AutoHelper, use persistent link key

### DIFF
--- a/apps/autohelper/autohelper/config/settings.py
+++ b/apps/autohelper/autohelper/config/settings.py
@@ -64,8 +64,7 @@ class Settings(BaseSettings):
     # Context Layer / External Data Sources
     autoart_frontend_url: str = "http://localhost:5173"
     autoart_api_url: str = "http://localhost:3001"
-    autoart_api_key: str = ""  # Optional API key for AutoArt
-    autoart_session_id: str = ""  # Session ID from AutoArt pairing (Monday token proxied via this)
+    autoart_link_key: str = ""  # Persistent link key from AutoArt pairing
     context_providers: list[str] = Field(default=["autoart", "monday"])  # Priority order
 
     # Artifact Storage Settings

--- a/apps/autohelper/autohelper/modules/config/router.py
+++ b/apps/autohelper/autohelper/modules/config/router.py
@@ -55,7 +55,7 @@ async def put_config(body: dict[str, Any]) -> dict[str, Any]:
     except Exception as exc:
         logger.warning("Failed to reinit mail service after config change: %s", exc)
 
-    # Reinitialise context service so autoart_session_id and other
+    # Reinitialise context service so link key and other
     # context-layer settings take effect without a restart.
     try:
         from autohelper.modules.context.service import ContextService

--- a/apps/autohelper/autohelper/modules/context/service.py
+++ b/apps/autohelper/autohelper/modules/context/service.py
@@ -96,15 +96,14 @@ class ContextService:
         config = config_store.load()
 
         # AutoArt client (local server, may not be running)
-        # Use session_id from ConfigStore if available, otherwise fall back to settings
+        # Use link_key from ConfigStore if available, otherwise fall back to settings
         autoart_url = getattr(self.settings, "autoart_api_url", "http://localhost:3001")
-        autoart_key = getattr(self.settings, "autoart_api_key", None)
-        autoart_session_id = config.get("autoart_session_id") or getattr(
-            self.settings, "autoart_session_id", ""
+        autoart_link_key = config.get("autoart_link_key") or getattr(
+            self.settings, "autoart_link_key", ""
         )
         try:
             self._autoart_client = AutoArtClient(
-                api_url=autoart_url, api_key=autoart_key, session_id=autoart_session_id
+                api_url=autoart_url, link_key=autoart_link_key or None
             )
         except Exception as e:
             logger.warning(f"Failed to init AutoArt client: {e}")

--- a/apps/autohelper/autohelper/modules/gc/router.py
+++ b/apps/autohelper/autohelper/modules/gc/router.py
@@ -92,8 +92,7 @@ async def get_gc_stats() -> GCStatsResponse:
     settings = get_settings()
     client = AutoArtClient(
         api_url=settings.autoart_api_url,
-        api_key=settings.autoart_api_key,
-        session_id=settings.autoart_session_id,
+        link_key=settings.autoart_link_key or None,
     )
 
     stats = client.get_gc_stats(retention_days=settings.gc_retention_days)

--- a/apps/autohelper/autohelper/modules/gc/service.py
+++ b/apps/autohelper/autohelper/modules/gc/service.py
@@ -77,8 +77,7 @@ class GarbageCollectionService:
         if self._client is None:
             self._client = AutoArtClient(
                 api_url=self._settings.autoart_api_url,
-                api_key=self._settings.autoart_api_key,
-                session_id=self._settings.autoart_session_id,
+                link_key=self._settings.autoart_link_key or None,
             )
         return self._client
 

--- a/apps/autohelper/autohelper/modules/gc/tasks/api_cleanup.py
+++ b/apps/autohelper/autohelper/modules/gc/tasks/api_cleanup.py
@@ -30,8 +30,7 @@ def cleanup_import_sessions(
         settings = get_settings()
         client = AutoArtClient(
             api_url=settings.autoart_api_url,
-            api_key=settings.autoart_api_key,
-            session_id=settings.autoart_session_id,
+            link_key=settings.autoart_link_key or None,
         )
 
     # Check if backend is reachable
@@ -74,8 +73,7 @@ def cleanup_export_sessions(
         settings = get_settings()
         client = AutoArtClient(
             api_url=settings.autoart_api_url,
-            api_key=settings.autoart_api_key,
-            session_id=settings.autoart_session_id,
+            link_key=settings.autoart_link_key or None,
         )
 
     # Check if backend is reachable


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #354**
  * **PR #355**
    * **PR #356**
      * **PR #357**
        * **PR #358**
          * **PR #359**
            * **PR #360**
              * **PR #361** 👈
                * **PR #362**
                  * **PR #363**
                    * **PR #364**
                      * **PR #365**
                        * **PR #366**
                          * **PR #368**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Switch AutoHelper pairing from transient session to persistent link key

### What Changed
- Pairing now accepts and persists a single persistent link key (frontend sends "key") instead of a temporary pairing code/session; pairing verifies the key with the backend before saving
- Unpair clears the persisted link key and legacy session/API key entries immediately so the tray and services reflect unpaired state
- All backend calls and internal clients use the link key in request headers; background tasks (GC, cleanup) and services now operate using the persisted link key when present
- Tray/status logic checks the presence of the link key in config for paired state (faster local detection) and no longer relies on session verification network calls

### Impact
`✅ Shorter pairing flow with a persistent link key`
`✅ Immediate and reliable tray pairing status`
`✅ Fewer stale legacy session entries after unpairing`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
