### PR TITLE
feat: improve MailCard controls coherency and state display

### DIFF
--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -161,6 +161,7 @@ export function SettingsPage() {
                             ) : derivedTab === 'autohelper' ? (
                                 <AutoHelperSection
                                     autohelperStatus={{ connected: connections?.autohelper?.connected ?? false }}
+                                    microsoftConnected={connections?.microsoft?.connected ?? false}
                                 />
                             ) : derivedTab === 'integrations' ? (
                                 <IntegrationsSection


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #354**
  * **PR #355**
    * **PR #356**
      * **PR #357**
        * **PR #358**
          * **PR #359**
            * **PR #360**
              * **PR #361**
                * **PR #362**
                  * **PR #363**
                    * **PR #364**
                      * **PR #365** 👈
                        * **PR #366**
                          * **PR #368**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Improve Mail settings controls and state display

### What Changed
- Mail card shows a clear state badge: "Disabled", "Running", or "Enabled (stopped)" with matching icons
- Poll interval input is editable locally, saves on blur or Enter, and is disabled when mail is disabled
- Start button is disabled when mail is disabled; disabling mail auto-queues a stop if mail is running
- Small helper texts added: hint when mail is disabled and a message prompting enable to start; shows "MS Graph mail available as fallback" when Microsoft connection exists
- AutoHelper section now forwards Microsoft connection status so the Mail card can show the fallback indicator

### Impact
`✅ Clearer mail running status`
`✅ Fewer accidental mail starts when disabled`
`✅ Shorter poll-interval updates (save on blur/Enter)`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
