### PR TITLE
fix: improve RootsCard UX with clearer placeholder and hint

### DIFF
--- a/frontend/src/pages/settings/AutoHelperSection.tsx
+++ b/frontend/src/pages/settings/AutoHelperSection.tsx
@@ -727,6 +727,7 @@ function RootsCard() {
     const { data: bridgeSettings } = useBridgeSettings();
     const updateSettings = useUpdateBridgeSettings();
     const [newRoot, setNewRoot] = useState('');
+    const inputRef = useRef<HTMLInputElement>(null);
 
     const roots: string[] = useMemo(
         () => bridgeSettings?.settings?.allowed_roots ?? [],
@@ -739,6 +740,8 @@ function RootsCard() {
         updateSettings.mutate({ allowed_roots: [...roots, trimmed] });
         setNewRoot('');
         toast.success('Root added');
+        // Keep focus on input for adding multiple roots
+        inputRef.current?.focus();
     }, [newRoot, roots, updateSettings]);
 
     const handleRemove = useCallback(
@@ -749,22 +752,34 @@ function RootsCard() {
         [roots, updateSettings],
     );
 
+    const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            handleAdd();
+        }
+    }, [handleAdd]);
+
     return (
         <CardShell
             icon={<HardDrive className="w-5 h-5 text-ws-text-secondary" />}
             iconBg="bg-[var(--ws-bg)]"
             title="Roots"
         >
+            <p className="text-xs text-ws-text-secondary mb-3">
+                Directories AutoHelper can access for indexing and collection.
+            </p>
+
             {roots.length === 0 ? (
-                <p className="text-sm text-ws-muted">No roots configured</p>
+                <p className="text-sm text-ws-muted py-2">No roots configured</p>
             ) : (
-                <ul className="space-y-1">
+                <ul className="space-y-1 mb-3">
                     {roots.map((root) => (
                         <li key={root} className="flex items-center gap-2 group">
                             <span className="text-sm text-ws-fg font-mono truncate flex-1">{root}</span>
                             <button
                                 onClick={() => handleRemove(root)}
                                 className="opacity-0 group-hover:opacity-100 text-ws-muted hover:text-[var(--ws-color-error)] transition-opacity"
+                                aria-label={`Remove ${root}`}
                             >
                                 <X className="w-4 h-4" />
                             </button>
@@ -773,14 +788,16 @@ function RootsCard() {
                 </ul>
             )}
 
-            <div className="flex gap-2 pt-2">
+            <div className="flex gap-2">
                 <TextInput
+                    ref={inputRef}
                     size="sm"
                     value={newRoot}
                     onChange={(e) => setNewRoot(e.target.value)}
-                    placeholder="/path/to/files"
-                    onKeyDown={(e) => e.key === 'Enter' && handleAdd()}
+                    placeholder="Type a path, then press Enter or click Add"
+                    onKeyDown={handleKeyDown}
                     className="flex-1"
+                    autoComplete="off"
                 />
                 <SmallButton onClick={handleAdd} disabled={!newRoot.trim()}>
                     <Plus className="w-3 h-3" /> Add


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #354**
  * **PR #355**
    * **PR #356**
      * **PR #357**
        * **PR #358**
          * **PR #359**
            * **PR #360**
              * **PR #361**
                * **PR #362**
                  * **PR #363**
                    * **PR #364**
                      * **PR #365**
                        * **PR #366** 👈
                          * **PR #368**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Improve Roots input: clearer hint, keep focus for rapid entry, and better remove affordance

### What Changed
- Input now shows an explicit instruction ("Type a path, then press Enter or click Add") and a short description above the card so users know what directories are for
- Pressing Enter adds the typed path; after adding the input stays focused so users can add multiple roots quickly
- Remove buttons get an accessible label and visible hover affordance; spacing adjusted for clearer list layout
- Input disables browser autocomplete to avoid distracting suggestions

### Impact
`✅ Faster adding of multiple roots`
`✅ Clearer guidance on what to enter`
`✅ Fewer accidental or unclear remove actions`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
