### PR TITLE
feat: create records from intake form submissions

### DIFF
--- a/backend/src/db/migrations/055_intake_record_creation.ts
+++ b/backend/src/db/migrations/055_intake_record_creation.ts
@@ -1,0 +1,22 @@
+/**
+ * Migration: Add created_records column to intake_submissions
+ *
+ * Stores array of records created from RecordBlocks during form submission.
+ * Format: [{ definitionId, recordId, uniqueName }, ...]
+ */
+
+import { Kysely, sql } from 'kysely';
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable('intake_submissions')
+    .addColumn('created_records', 'jsonb', (col) => col.defaultTo(sql`'[]'::jsonb`))
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable('intake_submissions')
+    .dropColumn('created_records')
+    .execute();
+}

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -555,6 +555,7 @@ export interface IntakeSubmissionsTable {
   form_id: string;
   upload_code: string;
   metadata: unknown; // JSONB
+  created_records: Generated<unknown>; // JSONB - [{ definitionId, recordId, uniqueName }]
   created_at: Generated<Date>;
 }
 

--- a/backend/src/modules/intake/intake.routes.ts
+++ b/backend/src/modules/intake/intake.routes.ts
@@ -249,6 +249,9 @@ export async function intakePublicRoutes(app: FastifyInstance) {
           id: submission.id,
           upload_code: submission.upload_code,
           created_at: submission.created_at,
+          created_records: submission.createdRecords.length > 0
+            ? submission.createdRecords
+            : undefined,
         },
       });
     }

--- a/shared/src/intake/schemas.ts
+++ b/shared/src/intake/schemas.ts
@@ -91,3 +91,28 @@ export const IntakeFormConfigSchema = z.object({
 });
 
 export type IntakeFormConfig = z.infer<typeof IntakeFormConfigSchema>;
+
+// ==================== SUBMISSION RESULT ====================
+
+/**
+ * Record created from a RecordBlock during form submission
+ */
+export const CreatedRecordSchema = z.object({
+    definitionId: z.string().uuid(),
+    recordId: z.string().uuid(),
+    uniqueName: z.string(),
+});
+
+export type CreatedRecord = z.infer<typeof CreatedRecordSchema>;
+
+/**
+ * Result returned after successful form submission
+ */
+export const IntakeSubmissionResultSchema = z.object({
+    id: z.string().uuid(),
+    upload_code: z.string(),
+    created_at: z.string().datetime(),
+    created_records: z.array(CreatedRecordSchema).optional(),
+});
+
+export type IntakeSubmissionResult = z.infer<typeof IntakeSubmissionResultSchema>;


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #369**
  * **PR #370**
    * **PR #371** 👈
      * **PR #372**
        * **PR #386**
          * **PR #381**
            * **PR #383**
              * **PR #382**
                * **PR #385**
                  * **PR #384**
                    * **PR #388**
                      * **PR #389**
                        * **PR #390**
                          * **PR #391**
                            * **PR #392**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Create records from intake form submissions and return them in the API response

### What Changed
- Intake submissions now create records for form blocks marked to create instances; those created records are stored on the submission and returned as created_records in the create-submission response when present
- Database migration adds a created_records JSONB column on intake_submissions to persist created record metadata (definitionId, recordId, uniqueName)
- Submission creation is wrapped in a transaction that inserts the submission, attempts record creation for each RecordBlock, updates the submission with created records, and continues if individual record creation fails (submission itself still succeeds)

### Impact
`✅ Creates records from intake submissions`
`✅ Returns created records in submission response`
`✅ Submission still succeeds when some record creations fail`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
