### PR TITLE
feat: authenticated poll results endpoint

### DIFF
--- a/frontend/src/api/hooks/polls.ts
+++ b/frontend/src/api/hooks/polls.ts
@@ -1,8 +1,16 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import type { Poll, CreatePollInput } from '@autoart/shared';
+import type { Poll, CreatePollInput, UpdatePollInput, DuplicatePollInput } from '@autoart/shared';
 import { api } from '../client';
 
 export const POLLS_QUERY_KEY = ['polls'] as const;
+
+/** Poll results from authenticated endpoint */
+export interface PollResults {
+  poll: Poll;
+  slotCounts: Record<string, number>;
+  bestSlots: string[];
+  totalResponses: number;
+}
 
 export function usePolls() {
   return useQuery({
@@ -31,5 +39,46 @@ export function useClosePoll() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: POLLS_QUERY_KEY });
     },
+  });
+}
+
+export function useUpdatePoll() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, updates }: { id: string; updates: UpdatePollInput }) =>
+      api.patch<{ poll: Poll }>(`/polls/${id}`, updates),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: POLLS_QUERY_KEY });
+    },
+  });
+}
+
+export function useDeletePoll() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.delete(`/polls/${id}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: POLLS_QUERY_KEY });
+    },
+  });
+}
+
+export function useDuplicatePoll() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, input }: { id: string; input?: DuplicatePollInput }) =>
+      api.post<{ poll: Poll }>(`/polls/${id}/duplicate`, input ?? {}),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: POLLS_QUERY_KEY });
+    },
+  });
+}
+
+export function usePollResults(pollId: string | null) {
+  return useQuery({
+    queryKey: ['poll', pollId, 'results'],
+    queryFn: () =>
+      api.get<{ results: PollResults }>(`/polls/${pollId}/results`).then((r) => r.results),
+    enabled: !!pollId,
   });
 }


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #373**
  * **PR #374** 👈
    * **PR #375**
      * **PR #376**
        * **PR #377**
          * **PR #378**
            * **PR #379**
              * **PR #380**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Add authenticated poll results endpoint and client hooks for poll management

### What Changed
- Poll creators can fetch authenticated poll results via a new backend endpoint that returns detailed results (counts per slot, best slots, total responses)
- Frontend: new hook to load authenticated poll results and a typed PollResults shape; added hooks to update, delete, and duplicate polls which refresh the polls list after changes
- Existing poll list behavior unchanged except it now reflects updates, deletions, and duplications automatically after those operations

### Impact
`✅ Creators can view detailed poll results securely`
`✅ Easier poll management from UI (edit, delete, duplicate)`
`✅ Poll list stays up-to-date after poll changes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
