### PR TITLE
fix: resolve [object Object] rendering and ContactPicker loading state

### DIFF
--- a/frontend/src/ui/composites/ActionsTableFlat.tsx
+++ b/frontend/src/ui/composites/ActionsTableFlat.tsx
@@ -21,6 +21,7 @@ import { useState, useMemo, useCallback } from 'react';
 import type { Action } from '@autoart/shared';
 
 import type { RecordDefinition } from '../../types';
+import { stringifyFieldValue } from '../../utils/stringifyFieldValue';
 import { UniversalTableCore, makeFlatRowModel, type TableColumn as CoreTableColumn, type TableRow } from '../table-core';
 
 // ==================== TYPES ====================
@@ -223,9 +224,8 @@ export function ActionsTableFlat({
                     // Show first 2 bindings with labels
                     const preview = nonTitleBindings.slice(0, 2).map((b: { fieldKey: string; value?: unknown }) => {
                         const value = b.value;
-                        const displayValue = typeof value === 'string'
-                            ? value.length > 20 ? value.slice(0, 20) + '…' : value
-                            : String(value ?? '');
+                        const str = stringifyFieldValue(value) ?? '';
+                        const displayValue = str.length > 20 ? str.slice(0, 20) + '…' : str;
                         return (
                             <span key={b.fieldKey} className="inline-flex items-center gap-1 mr-2">
                                 <Tag size={10} className="text-ws-muted" />

--- a/frontend/src/ui/composites/DataTableFlat.tsx
+++ b/frontend/src/ui/composites/DataTableFlat.tsx
@@ -29,6 +29,7 @@ import { useState, useMemo, useCallback } from 'react';
 import { buildFieldViewModel, type FieldViewModel, type FieldDefinition, type ProjectState, type EntityContext } from '@autoart/shared/domain';
 
 import type { DataRecord, RecordDefinition, FieldDef } from '../../types';
+import { stringifyFieldValue } from '../../utils/stringifyFieldValue';
 import { DataFieldWidget, type DataFieldKind } from '../../ui/molecules/DataFieldWidget';
 import { EditableCell } from '../../ui/molecules/EditableCell';
 import { StatusColumnSummary } from '../../ui/molecules/StatusColumnSummary';
@@ -429,7 +430,7 @@ export function DataTableFlat({
                     if (col.key === 'unique_name') return record.unique_name;
                     if (col.key === 'updated_at') return record.updated_at || '';
                     const val = record.data?.[col.key];
-                    return val == null ? null : String(val);
+                    return stringifyFieldValue(val);
                 } : undefined,
                 // cell renderer with EditableCell
                 cell: (row: TableRow) => {

--- a/frontend/src/ui/composites/DataTableHierarchy.tsx
+++ b/frontend/src/ui/composites/DataTableHierarchy.tsx
@@ -32,6 +32,7 @@ import type { FieldViewModel } from '@autoart/shared/domain';
 
 import type { HierarchyNode, FieldDef } from '../../types';
 import { type DataFieldKind } from '../../ui/molecules/DataFieldWidget';
+import { stringifyFieldValue } from '../../utils/stringifyFieldValue';
 import { EditableCell } from '../../ui/molecules/EditableCell';
 import { StatusColumnSummary } from '../../ui/molecules/StatusColumnSummary';
 import { StatusFieldEditor } from '../semantic/StatusFieldEditor';
@@ -312,7 +313,7 @@ export function DataTableHierarchy({
                 sortKey: (row: TableRow) => {
                     const node = row.data as HierarchyNode;
                     const val = getFieldValue(node, field.key, fallbacks);
-                    return val == null ? null : String(val);
+                    return stringifyFieldValue(val);
                 },
                 cell: (row: TableRow) => {
                     const node = row.data as HierarchyNode;

--- a/frontend/src/ui/overlay/views/CreateInvoiceView.tsx
+++ b/frontend/src/ui/overlay/views/CreateInvoiceView.tsx
@@ -30,7 +30,7 @@ export function CreateInvoiceView({
   );
 
   const createRecord = useCreateFinanceRecord();
-  const { data: clients = [] } = useContactsByGroup('Developer/Client');
+  const { data: clients = [], isPending: isLoadingClients } = useContactsByGroup('Developer/Client');
 
   const [invoiceNumber, setInvoiceNumber] = useState('');
   const [issueDate, setIssueDate] = useState(new Date().toLocaleDateString('en-CA'));
@@ -92,6 +92,7 @@ export function CreateInvoiceView({
           value={clientId}
           onChange={setClientId}
           placeholder="Select client"
+          isLoading={isLoadingClients}
         />
         <div className="grid grid-cols-2 gap-4">
           <TextInput

--- a/frontend/src/utils/stringifyFieldValue.ts
+++ b/frontend/src/utils/stringifyFieldValue.ts
@@ -1,0 +1,34 @@
+/**
+ * Safe value serialization for display and sort keys.
+ *
+ * Handles objects that would otherwise render as "[object Object]".
+ * Tries common display properties first, falls back to JSON.
+ */
+
+export function stringifyFieldValue(val: unknown): string | null {
+    if (val == null) return null;
+    if (typeof val === 'string') return val;
+    if (typeof val === 'number' || typeof val === 'boolean') return String(val);
+
+    // Array: join elements
+    if (Array.isArray(val)) {
+        return val.map(stringifyFieldValue).filter(Boolean).join(', ') || null;
+    }
+
+    // Object: try common display properties, then JSON
+    if (typeof val === 'object') {
+        const obj = val as Record<string, unknown>;
+        // Common display property names
+        for (const key of ['name', 'label', 'title', 'value', 'display', 'text']) {
+            if (typeof obj[key] === 'string') return obj[key];
+        }
+        // Fallback to JSON (compact)
+        try {
+            return JSON.stringify(val);
+        } catch {
+            return '[complex value]';
+        }
+    }
+
+    return String(val);
+}


### PR DESCRIPTION
## Summary

- Add `stringifyFieldValue` utility to safely serialize values for display/sort
- Fix `[object Object]` rendering in DataTableFlat, DataTableHierarchy, ActionsTableFlat
- Pass `isLoading` state to ContactPicker in CreateInvoiceView

## Details

**`[object Object]` bug:** Tables used `String(val)` to convert field values for sorting, which breaks on objects/arrays. New utility handles:
- Arrays: joins elements with comma
- Objects: extracts common display properties (name, label, title, value) or falls back to JSON

**ContactPicker loading:** The finance overlay showed "No contacts" while the query was still fetching. Now passes `isLoading` to show proper loading state.

## Test plan

- [ ] Open a table with object/array field values - should render properly, not `[object Object]`
- [ ] Open New Invoice overlay - should show "Loading..." while contacts fetch, then actual contacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #373**
  * **PR #374**
    * **PR #375**
      * **PR #376** 👈
        * **PR #377**
          * **PR #378**
            * **PR #379**
              * **PR #380**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->