### PR TITLE
feat: SubmissionsTable for intake responses

### DIFF
--- a/frontend/src/workflows/intake/components/SubmissionsTable.tsx
+++ b/frontend/src/workflows/intake/components/SubmissionsTable.tsx
@@ -1,0 +1,288 @@
+import { useState, useMemo } from 'react';
+import { ChevronDown, ChevronRight, Download, ExternalLink } from 'lucide-react';
+import { clsx } from 'clsx';
+
+import { Button, Badge, Spinner } from '@autoart/ui';
+import { useIntakeSubmissions } from '../../../api/hooks';
+import type { IntakeSubmission, CreatedRecord } from '@autoart/shared';
+
+// ==================== TYPES ====================
+
+interface SubmissionsTableProps {
+  formId: string;
+  /** Block labels for dynamic columns (blockId → label) */
+  blockLabels?: Map<string, string>;
+  /** Callback when clicking a created record badge */
+  onRecordClick?: (recordId: string) => void;
+}
+
+// ==================== HELPERS ====================
+
+function formatDate(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function exportToCSV(
+  submissions: IntakeSubmission[],
+  blockLabels: Map<string, string>
+): void {
+  // Build headers: Upload Code, Submitted At, [block labels], Created Records
+  const blockIds = Array.from(blockLabels.keys());
+  const headers = [
+    'Upload Code',
+    'Submitted At',
+    ...blockIds.map((id) => blockLabels.get(id) || id),
+    'Created Records',
+  ];
+
+  // Build rows
+  const rows = submissions.map((sub) => {
+    const metadata = sub.metadata as Record<string, unknown>;
+    const createdRecords = (sub as unknown as { created_records?: CreatedRecord[] })
+      .created_records;
+
+    return [
+      sub.upload_code,
+      formatDate(sub.created_at),
+      ...blockIds.map((id) => String(metadata[id] ?? '')),
+      createdRecords?.map((r) => r.uniqueName).join('; ') || '',
+    ];
+  });
+
+  // Convert to CSV string
+  const csvContent = [
+    headers.join(','),
+    ...rows.map((row) =>
+      row
+        .map((cell) => {
+          // Escape quotes and wrap in quotes if contains comma/newline
+          const escaped = String(cell).replace(/"/g, '""');
+          return /[,\n"]/.test(escaped) ? `"${escaped}"` : escaped;
+        })
+        .join(',')
+    ),
+  ].join('\n');
+
+  // Download
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `submissions-${new Date().toISOString().slice(0, 10)}.csv`;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+// ==================== MAIN COMPONENT ====================
+
+export function SubmissionsTable({
+  formId,
+  blockLabels = new Map(),
+  onRecordClick,
+}: SubmissionsTableProps) {
+  const { data: submissions, isLoading, error } = useIntakeSubmissions(formId);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-center py-8 text-ws-color-error">
+        Failed to load submissions
+      </div>
+    );
+  }
+
+  if (!submissions || submissions.length === 0) {
+    return (
+      <div className="text-center py-12 text-ws-text-secondary">
+        No submissions yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Header with export */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-ws-text-secondary">
+          {submissions.length} submission{submissions.length !== 1 ? 's' : ''}
+        </span>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => exportToCSV(submissions, blockLabels)}
+        >
+          <Download className="w-4 h-4 mr-1" />
+          Export CSV
+        </Button>
+      </div>
+
+      {/* Table */}
+      <div className="border border-ws-panel-border rounded-lg overflow-hidden">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="bg-ws-tabstrip-bg border-b border-ws-panel-border">
+              <th className="w-8" /> {/* Expand toggle */}
+              <th className="px-3 py-2 text-left font-medium text-ws-fg">
+                Upload Code
+              </th>
+              <th className="px-3 py-2 text-left font-medium text-ws-fg">
+                Submitted
+              </th>
+              <th className="px-3 py-2 text-left font-medium text-ws-fg">
+                Records
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {submissions.map((submission) => (
+              <SubmissionTableRow
+                key={submission.id}
+                submission={submission}
+                blockLabels={blockLabels}
+                onRecordClick={onRecordClick}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// ==================== ROW COMPONENT ====================
+
+interface SubmissionTableRowProps {
+  submission: IntakeSubmission;
+  blockLabels: Map<string, string>;
+  onRecordClick?: (recordId: string) => void;
+}
+
+function SubmissionTableRow({
+  submission,
+  blockLabels,
+  onRecordClick,
+}: SubmissionTableRowProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  // Extract created_records from submission (backend includes it but type might not)
+  const createdRecords = useMemo(() => {
+    const sub = submission as unknown as { created_records?: CreatedRecord[] };
+    return sub.created_records || [];
+  }, [submission]);
+
+  const metadata = submission.metadata as Record<string, unknown>;
+
+  return (
+    <>
+      <tr
+        className={clsx(
+          'border-b border-ws-panel-border cursor-pointer',
+          'hover:bg-ws-row-expanded-bg transition-colors',
+          expanded && 'bg-ws-row-expanded-bg'
+        )}
+        onClick={() => setExpanded(!expanded)}
+      >
+        {/* Expand toggle */}
+        <td className="px-2 py-2 text-center">
+          {expanded ? (
+            <ChevronDown className="w-4 h-4 text-ws-muted-fg" />
+          ) : (
+            <ChevronRight className="w-4 h-4 text-ws-muted-fg" />
+          )}
+        </td>
+
+        {/* Upload Code */}
+        <td className="px-3 py-2">
+          <code className="text-xs bg-ws-tabstrip-bg px-1.5 py-0.5 rounded">
+            {submission.upload_code}
+          </code>
+        </td>
+
+        {/* Submitted Date */}
+        <td className="px-3 py-2 text-ws-text-secondary">
+          {formatDate(submission.created_at)}
+        </td>
+
+        {/* Created Records */}
+        <td className="px-3 py-2">
+          {createdRecords.length > 0 ? (
+            <div className="flex flex-wrap gap-1">
+              {createdRecords.map((record) => (
+                <button
+                  key={record.recordId}
+                  type="button"
+                  className="inline-flex items-center"
+                  onClick={(e: React.MouseEvent) => {
+                    e.stopPropagation();
+                    onRecordClick?.(record.recordId);
+                  }}
+                >
+                  <Badge variant="info" className="cursor-pointer hover:opacity-80">
+                    {record.uniqueName}
+                    <ExternalLink className="w-3 h-3 ml-1" />
+                  </Badge>
+                </button>
+              ))}
+            </div>
+          ) : (
+            <span className="text-ws-text-disabled">—</span>
+          )}
+        </td>
+      </tr>
+
+      {/* Expanded row: show all field values */}
+      {expanded && (
+        <tr className="bg-ws-row-expanded-bg">
+          <td colSpan={4} className="px-4 py-3">
+            <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
+              {Object.entries(metadata).map(([blockId, value]) => {
+                // Skip internal fields (like those starting with underscore)
+                if (blockId.startsWith('_')) return null;
+
+                const label = blockLabels.get(blockId) || blockId;
+                const displayValue =
+                  value === null || value === undefined
+                    ? '(empty)'
+                    : typeof value === 'object'
+                      ? JSON.stringify(value)
+                      : String(value);
+
+                return (
+                  <div key={blockId} className="flex flex-col">
+                    <span className="text-ws-text-secondary text-xs">
+                      {label}
+                    </span>
+                    <span className="text-ws-fg truncate" title={displayValue}>
+                      {displayValue || '(empty)'}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Raw JSON fallback for debugging */}
+            {Object.keys(metadata).length === 0 && (
+              <pre className="text-xs text-ws-text-disabled">
+                {JSON.stringify(submission.metadata, null, 2)}
+              </pre>
+            )}
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #369**
  * **PR #370**
    * **PR #371**
      * **PR #372**
        * **PR #386**
          * **PR #381** 👈
            * **PR #383**
              * **PR #382**
                * **PR #385**
                  * **PR #384**
                    * **PR #388**
                      * **PR #389**
                        * **PR #390**
                          * **PR #391**
                            * **PR #392**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Add a submissions table for intake responses with CSV export and expandable details

### What Changed
- New submissions list view shows upload code, submitted date, and created-record badges for a form
- Rows are expandable to reveal all submitted field values (skips internal fields) and fall back to raw JSON if empty
- Users can export the visible submissions to a CSV file and click created-record badges to trigger a callback
- Shows a loading spinner, an error message on fetch failure, and a clear "No submissions yet." empty state

### Impact
`✅ Exportable submissions CSV`
`✅ Clickable created-record links`
`✅ Clearer submission detail inspection`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
