### PR TITLE
feat: Records tab in IntakeEditorView for block-to-field mapping

### DIFF
--- a/shared/src/schemas/intake/index.ts
+++ b/shared/src/schemas/intake/index.ts
@@ -5,7 +5,7 @@
  */
 
 import { z } from 'zod';
-import { FormBlockSchema } from '../../intake/schemas.js';
+import { FormBlockSchema, RecordMappingSchema } from '../../intake/schemas.js';
 
 export {
   ModuleBlockTypeSchema,
@@ -13,11 +13,15 @@ export {
   RecordBlockSchema,
   FormBlockSchema,
   IntakeFormConfigSchema,
+  RecordMappingSchema,
+  FieldMappingSchema,
   type ModuleBlockType,
   type ModuleBlock,
   type RecordBlock,
   type FormBlock,
-  type IntakeFormConfig
+  type IntakeFormConfig,
+  type RecordMapping,
+  type FieldMapping,
 } from '../../intake/schemas.js';
 
 // ==================== ENUMS ====================
@@ -58,6 +62,8 @@ export interface FormSettings {
  */
 export const IntakePageConfigSchema = z.object({
   blocks: z.array(FormBlockSchema),
+  /** Record mappings: connect form blocks to record fields */
+  recordMappings: z.array(RecordMappingSchema).optional(),
   settings: IntakePageSettingsSchema.optional(),
 });
 export type IntakePageConfig = z.infer<typeof IntakePageConfigSchema>;


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #369**
  * **PR #370**
    * **PR #371**
      * **PR #372**
        * **PR #386**
          * **PR #381**
            * **PR #383**
              * **PR #382**
                * **PR #385** 👈
                  * **PR #384**
                    * **PR #388**
                      * **PR #389**
                        * **PR #390**
                          * **PR #391**
                            * **PR #392**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
**Records tab in Intake editor to map form blocks to record fields**

### What Changed
- Added a new "Records" tab in the Intake editor that shows a Record Mapping panel where users can connect form blocks to record fields.
- Record mappings are loaded from the form page, can be edited in the UI, and are saved back to the page configuration automatically (debounced save with status feedback).
- The intake page schema now includes optional recordMappings so mappings persist with the form.

### Impact
`✅ Clearer record-to-field mapping`
`✅ Fewer lost mapping edits (auto-save with debounce)`
`✅ Shorter time to persist mapping changes`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
