### PR TITLE
feat: RecordMapping schema for block-to-field mapping

### DIFF
--- a/shared/src/intake/schemas.ts
+++ b/shared/src/intake/schemas.ts
@@ -74,11 +74,46 @@ export const FormBlockSchema = z.discriminatedUnion('kind', [
 
 export type FormBlock = z.infer<typeof FormBlockSchema>;
 
+// ==================== RECORD MAPPING ====================
+
+/**
+ * Maps a single ModuleBlock to a field in a RecordDefinition.
+ * Allows form blocks to populate record fields on submission.
+ */
+export const FieldMappingSchema = z.object({
+    /** FieldDef.key in the target RecordDefinition */
+    fieldKey: z.string(),
+    /** ModuleBlock.id to pull the value from */
+    blockId: z.string().uuid(),
+});
+
+export type FieldMapping = z.infer<typeof FieldMappingSchema>;
+
+/**
+ * Configures how form blocks map to a RecordDefinition.
+ * Staff can map multiple blocks to create a single record on submission.
+ */
+export const RecordMappingSchema = z.object({
+    id: z.string().uuid(),
+    /** Target RecordDefinition.id */
+    definitionId: z.string().uuid(),
+    /** Create record instance on submit (default: true) */
+    createInstance: z.boolean().default(true),
+    /** Field key to use as the record's unique_name */
+    nameFieldKey: z.string().optional(),
+    /** Block → field mappings */
+    fieldMappings: z.array(FieldMappingSchema),
+});
+
+export type RecordMapping = z.infer<typeof RecordMappingSchema>;
+
 // ==================== INTAKE FORM CONFIG ====================
 
 export const IntakeFormConfigSchema = z.object({
     /** Ordered list of blocks */
     blocks: z.array(FormBlockSchema),
+    /** Record mappings: connect form blocks to record fields */
+    recordMappings: z.array(RecordMappingSchema).optional(),
     /** Form-level settings */
     settings: z.object({
         /** Show progress bar */


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #369**
  * **PR #370**
    * **PR #371**
      * **PR #372**
        * **PR #386** 👈
          * **PR #381**
            * **PR #383**
              * **PR #382**
                * **PR #385**
                  * **PR #384**
                    * **PR #388**
                      * **PR #389**
                        * **PR #390**
                          * **PR #391**
                            * **PR #392**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
**Add RecordMapping to map form blocks to record fields on submit**

### What Changed
- Intake form configuration accepts recordMappings so staff can connect form blocks to a target record definition
- Each record mapping specifies the target definition, optional name field, whether to create a record on submit, and a list of block→field pairs (blockId → fieldKey)
- Form submissions can now populate record fields according to those mappings, or skip creating a record when configured

### Impact
`✅ Creates records from form submissions`
`✅ Configurable block-to-field mapping by staff`
`✅ Optional suppression of record creation per mapping`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
