### PR TITLE
feat: composer-routed submission pipeline for intake forms

### DIFF
--- a/backend/src/modules/intake/intake.composer.ts
+++ b/backend/src/modules/intake/intake.composer.ts
@@ -1,0 +1,302 @@
+/**
+ * Intake Composer - Processes block record bindings during form submission.
+ *
+ * Groups bound blocks by (definitionId, groupKey), then for each group:
+ * - mode='create': creates a record + Composer action + events
+ * - mode='link': auto-matches existing record, or creates new as fallback
+ *
+ * Runs within the submission transaction for atomicity.
+ */
+
+import type { Transaction } from 'kysely';
+
+import type { CreatedRecord, ComposerInput, ContextType, BlockRecordBinding } from '@autoart/shared';
+
+import type { Database } from '../../db/schema.js';
+import { db } from '../../db/client.js';
+import * as recordsService from '../records/records.service.js';
+import { compose } from '../composer/composer.service.js';
+
+interface BoundBlock {
+  blockId: string;
+  binding: BlockRecordBinding;
+  value: unknown;
+}
+
+interface BlockGroup {
+  definitionId: string;
+  groupKey: string;
+  mode: 'create' | 'link';
+  blocks: BoundBlock[];
+  linkMatchField?: string;
+}
+
+/**
+ * Process block bindings for a form submission.
+ * Loads form blocks, groups by (definitionId, groupKey), creates records + Composer actions.
+ */
+export async function processBlockBindings(
+  formId: string,
+  classificationNodeId: string,
+  metadata: Record<string, unknown>,
+  trx: Transaction<Database>
+): Promise<CreatedRecord[]> {
+  const createdRecords: CreatedRecord[] = [];
+
+  // Load form pages to find blocks with bindings
+  const pages = await trx
+    .selectFrom('intake_form_pages')
+    .selectAll()
+    .where('form_id', '=', formId)
+    .execute();
+
+  // Collect all bound blocks from all pages
+  const boundBlocks: BoundBlock[] = [];
+  for (const page of pages) {
+    const config = page.blocks_config as { blocks?: Array<{ id: string; recordBinding?: BlockRecordBinding }> };
+    if (!config?.blocks) continue;
+
+    for (const block of config.blocks) {
+      if (!block.recordBinding) continue;
+
+      boundBlocks.push({
+        blockId: block.id,
+        binding: block.recordBinding,
+        value: metadata[block.id],
+      });
+    }
+  }
+
+  if (boundBlocks.length === 0) return createdRecords;
+
+  // Resolve context type from classification node
+  const node = await trx
+    .selectFrom('hierarchy_nodes')
+    .select(['type'])
+    .where('id', '=', classificationNodeId)
+    .executeTakeFirst();
+
+  if (!node) return createdRecords;
+
+  // Templates aren't valid action contexts
+  if (node.type === 'template') return createdRecords;
+  const contextType = node.type as ContextType;
+
+  // Group blocks by (definitionId, groupKey)
+  const groupMap = new Map<string, BlockGroup>();
+  for (const bb of boundBlocks) {
+    const key = `${bb.binding.definitionId}::${bb.binding.groupKey ?? 'default'}`;
+    if (!groupMap.has(key)) {
+      groupMap.set(key, {
+        definitionId: bb.binding.definitionId,
+        groupKey: bb.binding.groupKey ?? 'default',
+        mode: bb.binding.mode,
+        blocks: [],
+        linkMatchField: bb.binding.linkMatchField,
+      });
+    }
+    groupMap.get(key)!.blocks.push(bb);
+  }
+
+  // Process each group
+  for (const group of groupMap.values()) {
+    const definition = await recordsService.getDefinitionById(group.definitionId);
+    if (!definition) continue;
+
+    // Aggregate block values into record data
+    const recordData: Record<string, unknown> = {};
+    for (const bb of group.blocks) {
+      recordData[bb.binding.fieldKey] = bb.value;
+    }
+
+    if (group.mode === 'create') {
+      const result = await processCreateGroup(
+        group, definition, recordData, classificationNodeId, contextType, formId, trx
+      );
+      if (result) createdRecords.push(result);
+    } else {
+      const result = await processLinkGroup(
+        group, definition, recordData, classificationNodeId, contextType, formId, trx
+      );
+      if (result) createdRecords.push(result);
+    }
+  }
+
+  return createdRecords;
+}
+
+async function processCreateGroup(
+  group: BlockGroup,
+  definition: { id: string; name: string },
+  recordData: Record<string, unknown>,
+  classificationNodeId: string,
+  contextType: ContextType,
+  formId: string,
+  trx: Transaction<Database>
+): Promise<CreatedRecord | null> {
+  const uniqueName = `${definition.name}-${Date.now()}`;
+
+  try {
+    const record = await recordsService.createRecord(
+      {
+        definitionId: group.definitionId,
+        uniqueName,
+        classificationNodeId,
+        data: recordData,
+      },
+      undefined,
+      trx
+    );
+
+    const composerInput: ComposerInput = {
+      action: {
+        contextId: classificationNodeId,
+        contextType,
+        type: definition.name,
+        fieldBindings: [],
+      },
+      references: [{ sourceRecordId: record.id, mode: 'dynamic' as const }],
+      emitExtraEvents: [{
+        type: 'FACT_RECORDED',
+        payload: {
+          factKind: 'DOCUMENT_SUBMITTED',
+          formId,
+          definitionId: group.definitionId,
+          recordId: record.id,
+        },
+      }],
+    };
+
+    await compose(composerInput, { actorId: null, skipView: true, trx });
+
+    return {
+      definitionId: group.definitionId,
+      recordId: record.id,
+      uniqueName: record.unique_name,
+    };
+  } catch (err) {
+    console.error(`[intake.composer] Failed to create record for group ${group.definitionId}:${group.groupKey}:`, err);
+    return null;
+  }
+}
+
+async function processLinkGroup(
+  group: BlockGroup,
+  definition: { id: string; name: string },
+  recordData: Record<string, unknown>,
+  classificationNodeId: string,
+  contextType: ContextType,
+  formId: string,
+  trx: Transaction<Database>
+): Promise<CreatedRecord | null> {
+  try {
+    let existingRecord: { id: string; unique_name: string } | undefined;
+
+    // Try to find existing record by linkMatchField
+    if (group.linkMatchField && recordData[group.linkMatchField] !== undefined) {
+      const matchValue = String(recordData[group.linkMatchField]);
+
+      const found = await trx
+        .selectFrom('records')
+        .select(['id', 'unique_name'])
+        .where('definition_id', '=', group.definitionId)
+        .where((eb) =>
+          eb(eb.fn('jsonb_extract_path_text', ['data', eb.val(group.linkMatchField!)]), '=', matchValue)
+        )
+        .executeTakeFirst();
+
+      existingRecord = found;
+    }
+
+    if (existingRecord) {
+      // Update existing record's fields with submitted values
+      const existingData = await trx
+        .selectFrom('records')
+        .select('data')
+        .where('id', '=', existingRecord.id)
+        .executeTakeFirst();
+
+      const merged = {
+        ...(typeof existingData?.data === 'object' && existingData?.data !== null ? existingData.data : {}),
+        ...recordData,
+      };
+
+      await trx
+        .updateTable('records')
+        .set({ data: JSON.stringify(merged) })
+        .where('id', '=', existingRecord.id)
+        .execute();
+
+      // Create Composer action referencing existing record
+      const composerInput: ComposerInput = {
+        action: {
+          contextId: classificationNodeId,
+          contextType,
+          type: definition.name,
+          fieldBindings: [],
+        },
+        references: [{ sourceRecordId: existingRecord.id, mode: 'dynamic' as const }],
+        emitExtraEvents: [{
+          type: 'FACT_RECORDED',
+          payload: {
+            factKind: 'DOCUMENT_SUBMITTED',
+            formId,
+            definitionId: group.definitionId,
+            linkedRecordId: existingRecord.id,
+          },
+        }],
+      };
+
+      await compose(composerInput, { actorId: null, skipView: true, trx });
+
+      return {
+        definitionId: group.definitionId,
+        recordId: existingRecord.id,
+        uniqueName: existingRecord.unique_name,
+      };
+    }
+
+    // Fallback: create new record
+    const uniqueName = `${definition.name}-${Date.now()}`;
+    const record = await recordsService.createRecord(
+      {
+        definitionId: group.definitionId,
+        uniqueName,
+        classificationNodeId,
+        data: recordData,
+      },
+      undefined,
+      trx
+    );
+
+    const composerInput: ComposerInput = {
+      action: {
+        contextId: classificationNodeId,
+        contextType,
+        type: definition.name,
+        fieldBindings: [],
+      },
+      references: [{ sourceRecordId: record.id, mode: 'dynamic' as const }],
+      emitExtraEvents: [{
+        type: 'FACT_RECORDED',
+        payload: {
+          factKind: 'intake_link_unresolved',
+          formId,
+          definitionId: group.definitionId,
+          recordId: record.id,
+        },
+      }],
+    };
+
+    await compose(composerInput, { actorId: null, skipView: true, trx });
+
+    return {
+      definitionId: group.definitionId,
+      recordId: record.id,
+      uniqueName: record.unique_name,
+    };
+  } catch (err) {
+    console.error(`[intake.composer] Failed to link record for group ${group.definitionId}:${group.groupKey}:`, err);
+    return null;
+  }
+}


### PR DESCRIPTION
## **User description**

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #404**
  * **PR #396**
    * **PR #397**
      * **PR #398**
        * **PR #399** 👈
          * **PR #400**
            * **PR #401**
              * **PR #402**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Composer-routed intake form submissions create or link records atomically

### What Changed
- Submitting a form with a classification node now processes blocks that declare record bindings and will create new records or link to existing records based on each block group’s mode.
- When a group is set to "link", the submission attempts to match an existing record by a configured field and updates that record; if no match is found it falls back to creating a new record.
- Record creation, Composer actions/events, and the submission save occur inside the same database transaction so either all changes are applied or none are.
- Composer and record creation functions accept an optional transaction so upstream callers (like submission flow) can run them inside the submission transaction.
- The submission row stores metadata about created records so callers can see which records were produced during submission.

### Impact
`✅ Creates records during form submission`
`✅ Atomic submissions with record creation and Composer actions`
`✅ Links form fields to existing records when matching values are present`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
