### PR TITLE
feat: inline block record binding editor for intake forms

### DIFF
--- a/frontend/src/workflows/intake/components/BlockRecordBindingEditor.tsx
+++ b/frontend/src/workflows/intake/components/BlockRecordBindingEditor.tsx
@@ -1,0 +1,188 @@
+/**
+ * BlockRecordBindingEditor - Inline record binding config for form blocks
+ *
+ * Appears between block preview and footer when active.
+ * Allows binding a block to a record definition field.
+ */
+
+import { useMemo } from 'react';
+import { Link2, X } from 'lucide-react';
+import { useRecordDefinitions, useRecordDefinition } from '../../../api/hooks/entities/definitions';
+import type { BlockRecordBinding, FormBlock } from '@autoart/shared';
+
+interface BlockRecordBindingEditorProps {
+    blockId: string;
+    binding: BlockRecordBinding | undefined;
+    allBlocks: FormBlock[];
+    onUpdate: (binding: BlockRecordBinding | undefined) => void;
+}
+
+export function BlockRecordBindingEditor({
+    blockId,
+    binding,
+    allBlocks,
+    onUpdate,
+}: BlockRecordBindingEditorProps) {
+    const { data: definitions } = useRecordDefinitions();
+    const { data: selectedDef } = useRecordDefinition(binding?.definitionId ?? null);
+
+    // Get fields from selected definition's schema_config
+    const definitionFields = useMemo(() => {
+        if (!selectedDef?.schema_config) return [];
+        const config = typeof selectedDef.schema_config === 'string'
+            ? JSON.parse(selectedDef.schema_config)
+            : selectedDef.schema_config;
+        return Array.isArray(config?.fields) ? config.fields : [];
+    }, [selectedDef]);
+
+    // Find sibling blocks in same group
+    const groupSiblings = useMemo(() => {
+        if (!binding?.groupKey) return [];
+        return allBlocks.filter(
+            (b) => b.id !== blockId && b.recordBinding?.groupKey === binding.groupKey
+        );
+    }, [allBlocks, blockId, binding?.groupKey]);
+
+    // Unbound state: show add button
+    if (!binding) {
+        return (
+            <button
+                onClick={() => {
+                    onUpdate({
+                        mode: 'create',
+                        definitionId: '',
+                        fieldKey: '',
+                    });
+                }}
+                className="flex items-center gap-2 text-xs text-ws-muted hover:text-[var(--ws-accent)] py-2 transition-colors"
+            >
+                <Link2 className="w-3 h-3" />
+                Link to record field
+            </button>
+        );
+    }
+
+    // Bound state: show config
+    return (
+        <div className="mt-3 mb-1 p-3 border border-ws-panel-border rounded-lg bg-ws-bg space-y-3">
+            <div className="flex items-center justify-between">
+                <span className="text-xs font-medium text-ws-text-secondary flex items-center gap-1.5">
+                    <Link2 className="w-3 h-3" />
+                    Record Binding
+                </span>
+                <button
+                    onClick={() => onUpdate(undefined)}
+                    className="text-ws-muted hover:text-red-500 p-0.5"
+                    title="Remove binding"
+                >
+                    <X className="w-3.5 h-3.5" />
+                </button>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+                {/* Definition select */}
+                <div>
+                    <label className="block text-[11px] text-ws-text-secondary mb-1">Definition</label>
+                    <select
+                        value={binding.definitionId}
+                        onChange={(e) => {
+                            const newDefId = e.target.value;
+                            const newBinding: BlockRecordBinding = {
+                                ...binding,
+                                definitionId: newDefId,
+                                fieldKey: '',
+                            };
+                            // Auto-assign group key if other blocks use same definition
+                            if (newDefId) {
+                                const existing = allBlocks.find(
+                                    (b) => b.id !== blockId && b.recordBinding?.definitionId === newDefId
+                                );
+                                if (existing?.recordBinding?.groupKey) {
+                                    newBinding.groupKey = existing.recordBinding.groupKey;
+                                } else {
+                                    newBinding.groupKey = `group-${newDefId.slice(0, 8)}`;
+                                }
+                            }
+                            onUpdate(newBinding);
+                        }}
+                        className="w-full px-2 py-1.5 border border-ws-panel-border rounded text-xs text-ws-fg bg-ws-panel-bg focus:outline-none focus:ring-1 focus:ring-[var(--ws-accent)]"
+                    >
+                        <option value="">Select...</option>
+                        {definitions?.map((d) => (
+                            <option key={d.id} value={d.id}>{d.name}</option>
+                        ))}
+                    </select>
+                </div>
+
+                {/* Field select */}
+                <div>
+                    <label className="block text-[11px] text-ws-text-secondary mb-1">Field</label>
+                    <select
+                        value={binding.fieldKey}
+                        onChange={(e) => onUpdate({ ...binding, fieldKey: e.target.value })}
+                        disabled={!binding.definitionId}
+                        className="w-full px-2 py-1.5 border border-ws-panel-border rounded text-xs text-ws-fg bg-ws-panel-bg focus:outline-none focus:ring-1 focus:ring-[var(--ws-accent)] disabled:opacity-50"
+                    >
+                        <option value="">Select...</option>
+                        {definitionFields.map((f: { key: string; label: string }) => (
+                            <option key={f.key} value={f.key}>{f.label}</option>
+                        ))}
+                    </select>
+                </div>
+            </div>
+
+            {/* Mode */}
+            <div className="flex items-center gap-4">
+                <label className="block text-[11px] text-ws-text-secondary">Mode</label>
+                <label className="flex items-center gap-1.5 text-xs">
+                    <input
+                        type="radio"
+                        name={`mode-${blockId}`}
+                        checked={binding.mode === 'create'}
+                        onChange={() => onUpdate({ ...binding, mode: 'create', linkMatchField: undefined })}
+                        className="text-[var(--ws-accent)]"
+                    />
+                    Create new
+                </label>
+                <label className="flex items-center gap-1.5 text-xs">
+                    <input
+                        type="radio"
+                        name={`mode-${blockId}`}
+                        checked={binding.mode === 'link'}
+                        onChange={() => onUpdate({ ...binding, mode: 'link' })}
+                        className="text-[var(--ws-accent)]"
+                    />
+                    Link existing
+                </label>
+            </div>
+
+            {/* Link match field (only for 'link' mode) */}
+            {binding.mode === 'link' && (
+                <div>
+                    <label className="block text-[11px] text-ws-text-secondary mb-1">Match field</label>
+                    <select
+                        value={binding.linkMatchField ?? ''}
+                        onChange={(e) => onUpdate({ ...binding, linkMatchField: e.target.value || undefined })}
+                        disabled={!binding.definitionId}
+                        className="w-full px-2 py-1.5 border border-ws-panel-border rounded text-xs text-ws-fg bg-ws-panel-bg focus:outline-none focus:ring-1 focus:ring-[var(--ws-accent)] disabled:opacity-50"
+                    >
+                        <option value="">Auto-match by...</option>
+                        {definitionFields.map((f: { key: string; label: string }) => (
+                            <option key={f.key} value={f.key}>{f.label}</option>
+                        ))}
+                    </select>
+                </div>
+            )}
+
+            {/* Group info */}
+            {binding.groupKey && groupSiblings.length > 0 && (
+                <div className="text-[11px] text-ws-text-secondary">
+                    Group: {binding.groupKey}
+                    <span className="ml-2 text-ws-muted">
+                        with {groupSiblings.map(b => b.label).join(', ')}
+                    </span>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/src/workflows/intake/components/IntakeCanvas.tsx
+++ b/frontend/src/workflows/intake/components/IntakeCanvas.tsx
@@ -33,6 +33,7 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import type { FormBlock } from '@autoart/shared';
 import { EditorBlockRenderer } from './editor-blocks';
+import { BlockRecordBindingEditor } from './BlockRecordBindingEditor';
 
 interface IntakeCanvasProps {
     blocks: FormBlock[];
@@ -71,6 +72,7 @@ const layoutBlocks = [
 interface SortableBlockProps {
     block: FormBlock;
     isActive: boolean;
+    allBlocks: FormBlock[];
     onSelectBlock: (id: string) => void;
     onDeleteBlock: (id: string) => void;
     onUpdateBlock: (id: string, updates: Partial<FormBlock>) => void;
@@ -80,6 +82,7 @@ interface SortableBlockProps {
 function SortableBlock({
     block,
     isActive,
+    allBlocks,
     onSelectBlock,
     onDeleteBlock,
     onUpdateBlock,
@@ -133,9 +136,17 @@ function SortableBlock({
                     </div>
 
                     {/* Block-specific preview */}
-                    <div className="mb-6">
+                    <div className="mb-4">
                         <EditorBlockRenderer block={block} isActive={true} onUpdate={onUpdateBlock} />
                     </div>
+
+                    {/* Inline Record Binding Editor */}
+                    <BlockRecordBindingEditor
+                        blockId={block.id}
+                        binding={block.recordBinding}
+                        allBlocks={allBlocks}
+                        onUpdate={(binding) => onUpdateBlock(block.id, { recordBinding: binding })}
+                    />
 
                     {/* Footer Actions */}
                     <div className="flex items-center justify-end gap-4 pt-4 border-t border-ws-panel-border">
@@ -297,6 +308,7 @@ export function IntakeCanvas({
                             key={block.id}
                             block={block}
                             isActive={block.id === activeBlockId}
+                            allBlocks={blocks}
                             onSelectBlock={onSelectBlock}
                             onDeleteBlock={onDeleteBlock}
                             onUpdateBlock={onUpdateBlock}


### PR DESCRIPTION
## **User description**

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #404**
  * **PR #396**
    * **PR #397**
      * **PR #398**
        * **PR #399**
          * **PR #400**
            * **PR #401** 👈
              * **PR #402**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Inline record binding editor for form blocks

### What Changed
- Unbound blocks show a "Link to record field" button; clicking opens an inline binding panel under the block preview.
- Bound blocks show a compact editor to choose a record definition, pick a field, switch between "Create new" and "Link existing" modes, set a match field for linking, and remove the binding.
- Selecting a definition auto-assigns or reuses a group identifier when other blocks use the same definition; bound blocks display their group and sibling labels.
- The binding editor populates field options from the selected record definition so only valid fields are selectable.
- The editor is embedded directly in the intake canvas beneath each block preview.

### Impact
`✅ Shorter binding setup for form blocks`
`✅ Clearer binding removal and mode switching`
`✅ Fewer incorrect group assignments when reusing definitions`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
