### PR TITLE
fix: humanize import column headers from snake_case/camelCase to Title Case

### DIFF
--- a/frontend/src/ui/composites/DataTableImport.tsx
+++ b/frontend/src/ui/composites/DataTableImport.tsx
@@ -72,6 +72,18 @@ export interface DataTableImportProps {
 // ============================================================================
 
 /**
+ * Convert field names from snake_case/camelCase to human-readable Title Case.
+ * "status_text" → "Status Text", "targetDate" → "Target Date"
+ */
+function humanizeFieldName(fieldName: string): string {
+    return fieldName
+        .replace(/([a-z])([A-Z])/g, '$1 $2')
+        .replace(/[_-]/g, ' ')
+        .replace(/\b\w/g, (c) => c.toUpperCase())
+        .trim();
+}
+
+/**
  * Discover all unique fields from import plan items
  */
 export function discoverImportFields(plan: ImportPlan): ImportFieldDef[] {
@@ -105,7 +117,7 @@ export function discoverImportFields(plan: ImportPlan): ImportFieldDef[] {
             fieldName,
             renderHint,
             width: getWidthForRenderHint(renderHint),
-            label: fieldName,
+            label: humanizeFieldName(fieldName),
         }));
 }
 
@@ -141,7 +153,7 @@ export function discoverFieldsForItems(items: ImportPlanItem[]): ImportFieldDef[
             fieldName,
             renderHint,
             width: getWidthForRenderHint(renderHint),
-            label: fieldName,
+            label: humanizeFieldName(fieldName),
         }));
 }
 


### PR DESCRIPTION
## **User description**

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #406**
  * **PR #407** 👈
    * **PR #408**
      * **PR #410**

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Humanize import column headers from snake_case/camelCase to Title Case

### What Changed
- Import preview and generated column headers now display field names in Title Case (e.g., "status_text" → "Status Text", "targetDate" → "Target Date")
- Headers used for both top-level and nested/imported-field lists are human-readable instead of raw snake_case/camelCase identifiers

### Impact
`✅ Clearer import column labels`
`✅ Fewer mapping mistakes when matching source columns`
`✅ Faster identification of fields during import`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
