### PR TITLE
fix: restore lost ClassificationRow interactive functionality

### DIFF
--- a/frontend/src/workflows/import/components/ClassificationRow.tsx
+++ b/frontend/src/workflows/import/components/ClassificationRow.tsx
@@ -2,8 +2,9 @@ import { Check, ChevronDown, FileText, Lightbulb, Sparkles } from 'lucide-react'
 import type { ItemClassification, ClassificationSuggestion } from '../../../api/hooks/imports';
 import type { PendingResolution } from '../types';
 import { OUTCOME_OPTIONS } from '../constants';
-import { OutcomeIcon, getOutputKindBadge, formatSuggestionLabel, getConfidenceColor, isSuggestionSelected } from '../utils';
+import { OutcomeIcon, getOutputKindBadge, formatSuggestionLabel, isSuggestionSelected } from '../utils';
 import { toFactKindKey, formatRuleSource, humanizeFactKind } from '../../../utils/formatFactKind';
+import { Button, Badge, Text, TextInput, Stack, Inline } from '@autoart/ui';
 
 interface ClassificationRowProps {
     classification: ItemClassification;
@@ -33,17 +34,14 @@ export function ClassificationRow({
     const needsResolution = !classification.resolution &&
         (classification.outcome === 'AMBIGUOUS' || classification.outcome === 'UNCLASSIFIED');
 
-    // Get outputs from interpretation plan
     const outputs = classification.interpretationPlan?.outputs ?? [];
 
-    // Check if row has expandable content
     const hasExpandableContent = needsResolution ||
         outputs.length > 0 ||
         classification.candidates?.length ||
         (suggestions && suggestions.length > 0) ||
         classification.resolution;
 
-    // Only allow toggle if there's content to show
     const handleRowClick = () => {
         if (hasExpandableContent) {
             onToggle();
@@ -52,63 +50,66 @@ export function ClassificationRow({
 
     return (
         <div className={`border-b border-ws-panel-border last:border-b-0 ${needsResolution
-            ? 'bg-red-50/60 border-l-4 border-l-red-400'
+            ? 'bg-[color:var(--ws-color-error)]/5 border-l-4 border-l-[color:var(--ws-color-error)]'
             : ''
             }`}>
             {/* Item row */}
-            <div
-                className={`flex items-center gap-3 px-6 py-3 ${hasExpandableContent ? 'hover:bg-ws-bg cursor-pointer' : ''}`}
+            <Inline
+                gap="sm"
+                align="center"
+                wrap={false}
+                className={`px-6 py-3 ${hasExpandableContent ? 'hover:bg-ws-row-expanded-bg cursor-pointer' : ''}`}
                 onClick={handleRowClick}
             >
                 <OutcomeIcon
                     outcome={classification.outcome}
-                    className={`w-4 h-4 flex-shrink-0 ${needsResolution ? 'text-amber-600' : 'text-ws-muted'}`}
+                    className={`w-4 h-4 flex-shrink-0 ${needsResolution ? 'text-[var(--ws-color-warning)]' : 'text-ws-muted'}`}
                 />
 
-                <div className="flex-1 min-w-0">
-                    <p className="font-medium text-ws-fg truncate">{itemTitle}</p>
-                    <p className="text-xs text-ws-text-secondary truncate">{classification.rationale}</p>
-                </div>
+                <Stack gap="none" className="flex-1 min-w-0">
+                    <Text size="sm" weight="semibold" truncate>{itemTitle}</Text>
+                    <Text size="xs" color="dimmed" truncate>{classification.rationale}</Text>
+                </Stack>
 
                 {/* Output kind badges */}
-                <div className="flex items-center gap-1.5">
+                <Inline gap="xs" wrap={false}>
                     {outputs.slice(0, 2).map((output, idx) => {
                         const badge = getOutputKindBadge(output);
                         const Icon = badge.icon;
                         return (
-                            <span key={idx} className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium ${badge.color}`}>
-                                <Icon className="w-3 h-3" />
-                                {badge.label}
-                            </span>
+                            <Badge key={idx} size="xs" variant="neutral" className={badge.color}>
+                                <Inline gap="xs" align="center" wrap={false}>
+                                    <Icon className="w-3 h-3" />
+                                    {badge.label}
+                                </Inline>
+                            </Badge>
                         );
                     })}
                     {outputs.length > 2 && (
-                        <span className="text-[10px] text-ws-muted bg-slate-100 px-1.5 py-0.5 rounded">
-                            +{outputs.length - 2} more
-                        </span>
+                        <Badge size="xs" variant="neutral">+{outputs.length - 2}</Badge>
                     )}
-                </div>
+                </Inline>
 
-                {/* Confidence badge */}
-                <span className={`px-2 py-0.5 text-xs font-medium rounded ${getConfidenceColor(classification.confidence)}`}>
+                <Badge size="sm" variant={
+                    classification.confidence === 'high' ? 'success'
+                        : classification.confidence === 'medium' ? 'warning'
+                            : 'error'
+                }>
                     {classification.confidence}
-                </span>
+                </Badge>
 
-                {/* Outcome badge */}
-                <span className={`px-2 py-0.5 text-xs font-medium rounded ${needsResolution ? 'bg-amber-200 text-amber-800' : 'bg-slate-100 text-ws-text-secondary'}`}>
+                <Badge size="sm" variant={needsResolution ? 'warning' : 'neutral'}>
                     {classification.outcome}
-                </span>
+                </Badge>
 
-                {/* Inline Pending Resolution Status */}
                 {pending?.outcome && (
-                    <span className="px-2 py-0.5 text-xs font-medium rounded bg-green-100 text-green-700">
+                    <Badge size="sm" variant="success">
                         → {pending.outcome}
                         {pending.factKind && ` (${humanizeFactKind(pending.factKind)})`}
                         {pending.hintType && ` (${pending.hintType.charAt(0).toUpperCase() + pending.hintType.slice(1)})`}
-                    </span>
+                    </Badge>
                 )}
 
-                {/* Expand/Collapse Chevron */}
                 {hasExpandableContent ? (
                     <ChevronDown
                         className={`w-4 h-4 text-ws-muted transition-transform ${isExpanded ? 'rotate-180' : ''}`}
@@ -116,80 +117,77 @@ export function ClassificationRow({
                 ) : (
                     <div className="w-4 h-4" />
                 )}
-            </div>
+            </Inline>
 
             {/* Expanded details */}
             {isExpanded && hasExpandableContent && (
-                <div className="px-6 py-4 bg-ws-bg border-t border-ws-panel-border space-y-4">
+                <Stack gap="md" className="px-6 py-4 bg-ws-row-expanded-bg border-t border-ws-panel-border">
 
                     {/* Interpretation outputs */}
                     {outputs.length > 0 && (
-                        <div>
-                            <p className="text-xs font-medium text-ws-text-secondary mb-2">
-                                Interpretation outputs:
-                            </p>
-                            <div className="flex flex-wrap gap-2">
+                        <Stack gap="xs">
+                            <Text size="xs" color="dimmed">Interpretation outputs:</Text>
+                            <Inline gap="sm">
                                 {outputs.map((output, idx) => {
                                     const badge = getOutputKindBadge(output);
                                     const Icon = badge.icon;
                                     return (
-                                        <div
-                                            key={idx}
-                                            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg border ${badge.color} border-current/20`}
+                                        <Inline key={idx} gap="xs" align="center" wrap={false}
+                                            className={`px-3 py-1.5 rounded-lg border border-ws-panel-border ${badge.color}`}
                                         >
                                             <Icon className="w-3.5 h-3.5" />
-                                            <span className="text-sm font-medium">{badge.label}</span>
-                                            <span className="text-xs opacity-70">({output.kind})</span>
-                                        </div>
+                                            <Text size="sm">{badge.label}</Text>
+                                            <Text size="xs" color="dimmed">({output.kind})</Text>
+                                        </Inline>
                                     );
                                 })}
-                            </div>
-                        </div>
+                            </Inline>
+                        </Stack>
                     )}
 
                     {/* Candidates for AMBIGUOUS items */}
                     {classification.candidates && classification.candidates.length > 0 && (
-                        <div>
-                            <p className="text-xs font-medium text-ws-text-secondary mb-2">
-                                Possible fact kinds:
-                            </p>
-                            <div className="flex flex-wrap gap-2">
+                        <Stack gap="xs">
+                            <Text size="xs" color="dimmed">Possible fact kinds:</Text>
+                            <Inline gap="sm">
                                 {classification.candidates.map((candidate) => (
-                                    <button
+                                    <Button
                                         key={candidate}
+                                        size="sm"
+                                        variant={pending?.factKind === candidate ? 'primary' : 'secondary'}
                                         onClick={(e) => {
                                             e.stopPropagation();
                                             onFactKindSelect(candidate);
                                             onOutcomeSelect('FACT_EMITTED');
                                         }}
-                                        className={`px-3 py-1 text-sm rounded-full border transition-colors ${pending?.factKind === candidate
-                                            ? 'bg-blue-500 text-white border-blue-500'
-                                            : 'bg-ws-panel-bg text-ws-text-secondary border-ws-panel-border hover:border-blue-300'
-                                            }`}
+                                        className="rounded-full"
                                     >
                                         {candidate}
-                                    </button>
+                                    </Button>
                                 ))}
-                            </div>
-                        </div>
+                            </Inline>
+                        </Stack>
                     )}
 
-                    {/* Suggestions (for UNCLASSIFIED items) */}
+                    {/* Suggestions */}
                     {suggestions && suggestions.length > 0 && (
-                        <div>
-                            <p className="text-xs font-medium text-emerald-600 mb-2 flex items-center gap-1">
-                                <Sparkles className="w-3 h-3" />
-                                Suggested classifications:
-                            </p>
-                            <div className="flex flex-wrap gap-2">
+                        <Stack gap="xs">
+                            <Inline gap="xs" align="center">
+                                <Sparkles className="w-3 h-3 text-[var(--ws-color-success)]" />
+                                <Text size="xs" className="text-[var(--ws-color-success)]">Suggested classifications:</Text>
+                            </Inline>
+                            <Inline gap="sm">
                                 {suggestions.map((suggestion, idx) => {
                                     const label = formatSuggestionLabel(suggestion);
                                     const isSelected = isSuggestionSelected(suggestion, pending);
                                     const isFactCandidate = !!suggestion.factKind;
 
                                     return (
-                                        <button
+                                        <Button
                                             key={idx}
+                                            size="sm"
+                                            variant={isSelected ? 'primary' : 'light'}
+                                            color={isSelected ? undefined : 'green'}
                                             onClick={(e) => {
                                                 e.stopPropagation();
                                                 if (suggestion.factKind) {
@@ -199,99 +197,91 @@ export function ClassificationRow({
                                                     onHintTypeSelect(suggestion.hintType);
                                                 }
                                             }}
-                                            className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg border transition-colors ${isSelected
-                                                ? 'bg-emerald-500 text-white border-emerald-500'
-                                                : 'bg-emerald-50 text-emerald-700 border-emerald-200 hover:border-emerald-400'
-                                                }`}
                                             title={suggestion.reason}
+                                            leftSection={isFactCandidate
+                                                ? <FileText className="w-3 h-3" />
+                                                : <Lightbulb className="w-3 h-3" />
+                                            }
                                         >
-                                            {isFactCandidate ? (
-                                                <FileText className="w-3 h-3" />
-                                            ) : (
-                                                <Lightbulb className="w-3 h-3" />
-                                            )}
-                                            <span className="font-medium">{label}</span>
-                                            <span className={`text-[10px] px-1 py-0.5 rounded ${isSelected
-                                                ? 'bg-ws-panel-bg/20 text-white'
-                                                : getConfidenceColor(suggestion.confidence)
-                                                }`}>
+                                            {label}
+                                            <Badge size="xs" variant={isSelected ? 'neutral' : (
+                                                suggestion.confidence === 'high' ? 'success'
+                                                    : suggestion.confidence === 'medium' ? 'warning'
+                                                        : 'error'
+                                            )} className={isSelected ? 'bg-white/20 text-white border-transparent' : ''}>
                                                 {suggestion.matchScore}%
-                                            </span>
-                                            <span className={`text-[9px] px-1 py-0.5 rounded ${isSelected ? 'bg-ws-panel-bg/10 text-white/70' : 'bg-slate-100 text-ws-text-secondary'
-                                                }`}>
-                                                [{formatRuleSource(suggestion.ruleSource ?? '')}]
-                                            </span>
-                                        </button>
+                                            </Badge>
+                                            <Badge size="xs" variant="neutral"
+                                                className={isSelected ? 'bg-white/10 text-white/70 border-transparent' : ''}
+                                            >
+                                                {formatRuleSource(suggestion.ruleSource ?? '')}
+                                            </Badge>
+                                        </Button>
                                     );
                                 })}
-                            </div>
-                        </div>
+                            </Inline>
+                        </Stack>
                     )}
 
-                    {/* Outcome selection (only for items needing resolution) */}
+                    {/* Outcome selection */}
                     {needsResolution && (
-                        <div>
-                            <p className="text-xs font-medium text-ws-text-secondary mb-2">
-                                Resolve as:
-                            </p>
-                            <div className="flex flex-wrap gap-2">
+                        <Stack gap="xs">
+                            <Text size="xs" color="dimmed">Resolve as:</Text>
+                            <Inline gap="sm">
                                 {OUTCOME_OPTIONS.map((option) => {
                                     const Icon = option.icon;
                                     const isSelected = pending?.outcome === option.value;
                                     return (
-                                        <button
+                                        <Button
                                             key={option.value}
+                                            size="sm"
+                                            variant={isSelected ? 'primary' : 'secondary'}
                                             onClick={(e) => {
                                                 e.stopPropagation();
                                                 onOutcomeSelect(option.value);
                                             }}
-                                            className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-lg border transition-colors ${isSelected
-                                                ? 'bg-slate-800 text-white border-slate-800'
-                                                : 'bg-ws-panel-bg text-ws-text-secondary border-ws-panel-border hover:border-slate-400'
-                                                }`}
+                                            leftSection={<Icon className={`w-3.5 h-3.5 ${isSelected ? '' : option.color}`} />}
                                         >
-                                            <Icon className={`w-3.5 h-3.5 ${isSelected ? 'text-white' : option.color}`} />
                                             {option.label}
-                                        </button>
+                                        </Button>
                                     );
                                 })}
-                            </div>
+                            </Inline>
 
-                            {/* Custom fact kind input - appears when FACT_EMITTED is selected */}
+                            {/* Custom fact kind input */}
                             {pending?.outcome === 'FACT_EMITTED' && !pending?.factKind && (
-                                <div className="mt-3 pt-3 border-t border-ws-panel-border">
-                                    <label className="block text-xs font-medium text-ws-text-secondary mb-1.5">
-                                        Or enter a custom fact type:
-                                    </label>
-                                    <input
-                                        type="text"
+                                <Stack gap="xs" className="mt-3 pt-3 border-t border-ws-panel-border">
+                                    <TextInput
+                                        label="Or enter a custom fact type"
+                                        size="sm"
                                         value={pending?.customFactLabel ?? ''}
                                         onChange={(e) => onCustomFactLabelChange(e.target.value)}
                                         onClick={(e) => e.stopPropagation()}
                                         placeholder="e.g., Fee Proposal Submitted"
-                                        className="w-full px-3 py-2 text-sm border border-ws-panel-border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent placeholder:text-ws-muted"
                                     />
                                     {pending?.customFactLabel && (
-                                        <p className="mt-1.5 text-xs text-ws-text-secondary">
-                                            Will be stored as: <code className="bg-slate-100 px-1 py-0.5 rounded text-ws-text-secondary">{toFactKindKey(pending.customFactLabel)}</code>
-                                        </p>
+                                        <Text size="xs" color="dimmed">
+                                            Will be stored as: <code className="bg-ws-mono-bg px-1 py-0.5 rounded text-ws-mono-fg font-mono">{toFactKindKey(pending.customFactLabel)}</code>
+                                        </Text>
                                     )}
-                                </div>
+                                </Stack>
                             )}
-                        </div>
+                        </Stack>
                     )}
 
                     {/* Resolved status */}
                     {classification.resolution && (
-                        <div className="flex items-center gap-2 text-sm text-green-700">
-                            <Check className="w-4 h-4" />
-                            Resolved as: {classification.resolution.resolvedOutcome}
-                            {classification.resolution.resolvedFactKind && (
-                                <span className="font-medium">({classification.resolution.resolvedFactKind})</span>
-                            )}
-                        </div>
+                        <Inline gap="xs" align="center">
+                            <Check className="w-4 h-4 text-[var(--ws-color-success)]" />
+                            <Text size="sm" className="text-[var(--ws-color-success)]">
+                                Resolved as: {classification.resolution.resolvedOutcome}
+                                {classification.resolution.resolvedFactKind && (
+                                    <Text as="span" weight="semibold"> ({classification.resolution.resolvedFactKind})</Text>
+                                )}
+                            </Text>
+                        </Inline>
                     )}
-                </div>
+                </Stack>
             )}
         </div>
     );

--- a/frontend/src/workflows/import/types.ts
+++ b/frontend/src/workflows/import/types.ts
@@ -1,6 +1,6 @@
 export interface PendingResolution {
     itemTempId: string;
-    outcome: 'FACT_EMITTED' | 'DERIVED_STATE' | 'INTERNAL_WORK' | 'EXTERNAL_WORK' | 'DEFERRED' | null;
+    outcome: 'FACT_EMITTED' | 'DERIVED_STATE' | 'INTERNAL_WORK' | 'EXTERNAL_WORK' | 'AMBIGUOUS' | 'UNCLASSIFIED' | 'DEFERRED' | null;
     factKind?: string;
     hintType?: string; // Track selected hint type for action_hints
     customFactLabel?: string; // User-entered custom fact kind label


### PR DESCRIPTION
## **User description**
The refactor from single-file ClassificationPanel to split
ClassificationRow dropped several interactive sections:

- Interpretation outputs: expanded view showing fact_candidate,
  action_hint, work_event, field_value badges with kind labels
- Candidates for AMBIGUOUS items: clickable fact-kind buttons that
  set both factKind AND outcome to FACT_EMITTED
- Inline confidence badge (high/medium/low) on each row
- Inline outcome badge (AMBIGUOUS/UNCLASSIFIED/etc.) on each row
- Suggestion clicks now also set outcome (was only setting factKind)

Restored from git history at 7e9379a (pre-refactor state).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #406**
  * **PR #407**
    * **PR #408**
      * **PR #410** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Restore interactive elements and inline badges in ClassificationRow

### What Changed
- Shows inline confidence and outcome badges on each classification row so users see status at a glance
- Re-introduces expanded "Interpretation outputs" display with labeled output badges when rows are expanded
- Restores clickable candidate fact-kind buttons for AMBIGUOUS items; clicking a candidate now sets the fact kind and marks the outcome as FACT_EMITTED
- Restores suggestion buttons for UNCLASSIFIED items; clicking a suggestion that includes a fact kind now sets both fact kind and outcome, and hint suggestions set hint type
- Re-adds pending-resolution indicator text and keeps a compact resolved/resolution display
- Keeps outcome selection and custom fact-type input when FACT_EMITTED is chosen

### Impact
`✅ Clearer classification status with inline confidence and outcome badges`
`✅ Fewer manual steps to emit facts from suggestions or candidates`
`✅ Faster resolution of ambiguous/unclassified items`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
