### PR TITLE
fix: filter incomplete record bindings from intake auto-save

### DIFF
--- a/frontend/src/pages/Intake/IntakeEditorView.tsx
+++ b/frontend/src/pages/Intake/IntakeEditorView.tsx
@@ -123,8 +123,8 @@ export function IntakeEditorView({ formId, onBack }: IntakeEditorViewProps) {
                 // out until the user has completed the selection.
                 const cleanBlocks = blocks.map((block) => {
                     if (block.kind === 'module' && 'recordBinding' in block && block.recordBinding) {
-                        const binding = block.recordBinding as { definitionId?: string };
-                        if (!binding.definitionId) {
+                        const binding = block.recordBinding as { definitionId?: string; fieldKey?: string };
+                        if (!binding.definitionId || !binding.fieldKey) {
                             const { recordBinding: _, ...rest } = block;
                             return rest as FormBlock;
                         }


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #411** 👈
  * **PR #412**
    * **PR #413**
      * **PR #414**
        * **PR #415**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->

## Summary by Sourcery

Bug Fixes:
- Remove transient record bindings without a definitionId from blocks before persisting intake pages, avoiding backend schema validation errors.


___

## **CodeAnt-AI Description**
**Strip incomplete record bindings before intake autosave**

### What Changed
- Autosave now removes temporary "link to record" bindings that have no selected target before sending the page to the backend.
- Intake page saves no longer include bindings with empty definition IDs, preventing backend schema validation failures and save rejections.
- Autosave status continues to show success when save completes; failed saves due to incomplete bindings are avoided.

### Impact
`✅ Fewer backend validation errors during intake autosave`
`✅ Fewer failed autosaves for intake pages`
`✅ More reliable page persistence for partially edited record links`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
