### PR TITLE
fix: allow partial save in Classification Panel (unblock import wizard)

### DIFF
--- a/frontend/src/workflows/import/panels/ClassificationPanel.tsx
+++ b/frontend/src/workflows/import/panels/ClassificationPanel.tsx
@@ -245,12 +245,12 @@ export function ClassificationPanel({
         return Array.from(pendingResolutions.values()).filter((r) => r.outcome !== null).length;
     }, [pendingResolutions]);
 
-    // Check if all items are resolved
-    const allResolved = resolvedCount === unresolvedItems.length && unresolvedItems.length > 0;
+    // Check if there are any resolutions to save
+    const hasResolutions = resolvedCount > 0;
 
     // Handle save
     const handleSave = useCallback(async () => {
-        if (!sessionId || !allResolved) return;
+        if (!sessionId || !hasResolutions) return;
 
         const resolutions: Resolution[] = Array.from(pendingResolutions.values())
             .filter((r) => r.outcome !== null)
@@ -273,7 +273,7 @@ export function ClassificationPanel({
         } catch (err) {
             console.error('Failed to save resolutions:', err);
         }
-    }, [sessionId, allResolved, pendingResolutions, saveResolutionsMutation, onResolutionsSaved]);
+    }, [sessionId, hasResolutions, pendingResolutions, saveResolutionsMutation, onResolutionsSaved]);
 
     // No classifications at all
     if (allClassifications.length === 0) {
@@ -407,7 +407,7 @@ export function ClassificationPanel({
                                     e.stopPropagation();
                                     handleSave();
                                 }}
-                                disabled={!allResolved || saveResolutionsMutation.isPending}
+                                disabled={!hasResolutions || saveResolutionsMutation.isPending}
                                 className="flex items-center gap-2 px-4 py-1.5 text-sm font-medium text-white bg-amber-600 hover:bg-amber-700 disabled:bg-amber-300 rounded-lg transition-colors"
                             >
                                 {saveResolutionsMutation.isPending ? (


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #416**
  * **PR #417**
    * **PR #418** 👈
      * **PR #419**
        * **PR #420**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->

## Summary by Sourcery

Bug Fixes:
- Fix classification panel save logic to permit saving when at least one resolution is set, unblocking imports when not all items are resolved.


___

## **CodeAnt-AI Description**
Allow saving partial classifications so imports don't get blocked

### What Changed
- The panel now allows saving when at least one item has a chosen resolution instead of requiring every item to be resolved
- Save button and save handler are enabled/allowed whenever there is at least one resolution; saving clears pending resolutions and shows success feedback as before
- Save remains disabled when there are no resolutions or while a save is in progress

### Impact
`✅ Unblocked import wizard when some items remain unresolved`
`✅ Fewer stalled imports during manual review`
`✅ Clearer save availability in the classification panel`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
