### PR TITLE
fix: start intake and poll preview servers in pnpm dev

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -8,8 +8,9 @@
 # Services started:
 #   - Backend API (port 3001)
 #   - Frontend (port 5173)
-#   - AutoHelper Python service (port 8100)
-#   - Forms app (port 5174) - optional
+#   - Intake preview (port 5174)
+#   - Poll preview (port 5175)
+#   - AutoHelper Python service (port 8100) - if present
 
 set -euo pipefail
 
@@ -82,13 +83,17 @@ if [[ -f apps/autohelper/package.json ]]; then
     sleep 2
 fi
 
-# Start Forms if present
-if [[ -f apps/forms/package.json ]]; then
-    echo "[*] Starting Forms app..."
-    (cd apps/forms && pnpm dev) 2>&1 | sed 's/^/[FORMS] /' &
-    PIDS+=($!)
-    sleep 2
-fi
+# Start Intake preview (port 5174)
+echo "[*] Starting Intake preview server..."
+(cd frontend && pnpm dev:intake) 2>&1 | sed 's/^/[INTAKE] /' &
+PIDS+=($!)
+sleep 1
+
+# Start Poll preview (port 5175)
+echo "[*] Starting Poll preview server..."
+(cd frontend && pnpm dev:poll) 2>&1 | sed 's/^/[POLL] /' &
+PIDS+=($!)
+sleep 1
 
 echo ""
 echo "======================================"
@@ -97,8 +102,9 @@ echo "======================================"
 echo ""
 echo "  Frontend:   http://localhost:$FRONTEND_PORT"
 echo "  Backend:    http://localhost:$BACKEND_PORT"
+echo "  Intake:     http://localhost:5174"
+echo "  Poll:       http://localhost:5175"
 [[ -f apps/autohelper/package.json ]] && echo "  AutoHelper: http://localhost:$AUTOHELPER_PORT"
-[[ -f apps/forms/package.json ]] && echo "  Forms:      http://localhost:5174"
 echo ""
 echo "Press Ctrl+C to stop all services"
 echo ""


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #416**
  * **PR #417**
    * **PR #418**
      * **PR #419** 👈
        * **PR #420**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Start Intake and Poll preview servers when running the dev script

### What Changed
- The dev script now launches two frontend preview servers: Intake on port 5174 and Poll on port 5175 when running `pnpm dev`
- The previous automatic start of the Forms app was removed; Intake and Poll previews replace it
- The startup output now lists Intake and Poll URLs so developers can open those previews; AutoHelper remains optional and is started if present

### Impact
`✅ Can preview Intake locally at http://localhost:5174`
`✅ Can preview Poll locally at http://localhost:5175`
`✅ Clearer dev startup output for frontend previews`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

## Summary by Sourcery

Enhancements:
- Replace the optional Forms app startup with Intake and Poll preview servers when running `pnpm dev`.