### PR TITLE
feat: migrate panels to WorkspaceContext consumption

### DIFF
--- a/frontend/src/ui/panels/MailPanel.tsx
+++ b/frontend/src/ui/panels/MailPanel.tsx
@@ -22,6 +22,7 @@ import {
 import { usePromotedIds } from '../../api/hooks/mailMessages';
 import type { ProcessedEmail, Priority, TriageStatus as TriageStatusType } from '../../api/types/mail';
 import { EmailActionsMenu } from '../mail/EmailActionsMenu';
+import { useWorkspaceContextOptional } from '../../workspace/WorkspaceContext';
 
 const ITEMS_PER_PAGE = 25;
 
@@ -139,9 +140,14 @@ function StatusIndicator() {
     );
 }
 
-export function MailPanel(_props: IDockviewPanelProps) {
+export function MailPanel(props: IDockviewPanelProps) {
     const [offset, setOffset] = useState(0);
     const [useEnrichment, setUseEnrichment] = useState(true);
+
+    // When bound to a workspace project, filter mail to that project
+    const wsCtx = useWorkspaceContextOptional();
+    const isBound = wsCtx?.isBound(props.api.id) ?? false;
+    const projectFilter = isBound ? wsCtx?.boundProjectId ?? undefined : undefined;
 
     const { data: promotedIds } = usePromotedIds();
     const promotedSet = useMemo(
@@ -152,11 +158,13 @@ export function MailPanel(_props: IDockviewPanelProps) {
     const basicQuery = useInbox({
         limit: ITEMS_PER_PAGE,
         offset,
+        projectId: projectFilter,
     });
 
     const enrichedQuery = useEnrichedInbox({
         limit: ITEMS_PER_PAGE,
         offset,
+        projectId: projectFilter,
     });
 
     const { data, isLoading, isError, error, refetch, isFetching } = useEnrichment

--- a/frontend/src/ui/panels/ProjectPanel.tsx
+++ b/frontend/src/ui/panels/ProjectPanel.tsx
@@ -87,7 +87,7 @@ export function ProjectPanelContent({ panelId }: ProjectPanelProps) {
                                 {p.title}
                             </Menu.Item>
                         ))}
-                        {!isBound && boundProjectId && (
+                        {!isBound && ctx.boundProjectId && (
                             <>
                                 <Menu.Divider />
                                 <Menu.Item onClick={handleRebind} leftSection={<Unlink size={14} />}>


### PR DESCRIPTION
## **User description**
## Summary by Sourcery

Migrate selection inspector and mail/project panels to consume workspace context for workspace-bound behavior and scoping.

New Features:
- Scope mail inbox queries to the workspace-bound project when the mail panel is bound to a workspace.

Enhancements:
- Use workspace context to determine binding and workspace information in the selection inspector instead of direct bound panel ID usage.
- Use workspace context binding state for project panel content when deciding whether to show rebind options.
- Refine selection acceptance logic to depend on a workspace context–provided binding predicate rather than a bound panel ID set.


___

## **CodeAnt-AI Description**
Migrate panels to consume workspace context so workspace binding controls visible behavior

### What Changed
- Selection inspector now ignores selections that come from panels outside the current workspace when the inspector is bound to a workspace
- Mail panel automatically filters inbox queries to the workspace-bound project when the mail panel is bound to a workspace
- Project panel shows the "Re-bind to Workspace" option only when the panel is not bound and the workspace has a bound project

### Impact
`✅ Fewer cross-workspace selections`
`✅ Clearer, workspace-scoped mail results`
`✅ Clearer rebind option visibility in project panel`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #421**
  * **PR #422** 👈
    * **PR #423**
      * **PR #424**
        * **PR #425**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->