### PR TITLE
feat: migrate panels to WorkspaceContext consumption

### DIFF
--- a/frontend/src/types/workspace.ts
+++ b/frontend/src/types/workspace.ts
@@ -67,6 +67,8 @@ export interface WorkspacePreset {
     isBuiltIn: boolean;
     /** Scopes this custom workspace under a built-in workspace's submenu */
     parentWorkspaceId?: string;
+    /** Content types this workspace can display in center-workspace. Router validates against this. */
+    ownedContentTypes?: CenterContentType[];
     /** @deprecated Use subviews instead. Kept for backward compat with custom workspaces. */
     panels: WorkspacePanelConfig[];
     /** Named sub-configurations. Built-in workspaces should use this. */

--- a/frontend/src/ui/panels/ProjectPanel.tsx
+++ b/frontend/src/ui/panels/ProjectPanel.tsx
@@ -10,6 +10,7 @@ import { ChevronDown, Check, Unlink } from 'lucide-react';
 import type { IDockviewPanelProps } from 'dockview';
 
 import { useWorkspaceStore } from '../../stores/workspaceStore';
+import { useWorkspaceContext } from '../../workspace/WorkspaceContext';
 import { useProjects } from '../../api/hooks';
 import { ProjectView } from '../composites/ProjectView';
 import { Menu } from '@autoart/ui';
@@ -21,23 +22,21 @@ interface ProjectPanelProps {
 }
 
 export function ProjectPanelContent({ panelId }: ProjectPanelProps) {
-    const boundProjectId = useWorkspaceStore((s) => s.boundProjectId);
-    const boundPanelIds = useWorkspaceStore((s) => s.boundPanelIds);
-    const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
+    const ctx = useWorkspaceContext();
     const params = useWorkspaceStore((s) => s.panelParams.get(panelId));
     const { unbindPanel, markWorkspaceModified, setPanelParam, bindPanelToWorkspace } = useWorkspaceStore();
     const { data: projects } = useProjects();
 
     // Determine if this panel is bound to workspace
-    const isBound = boundPanelIds.has(panelId);
+    const isBound = ctx.isBound(panelId);
 
     // Get project ID: bound panels use workspace project, unbound use their own
     const overrideProjectId = (params as { projectId?: string })?.projectId;
-    const effectiveProjectId = isBound ? boundProjectId : overrideProjectId;
+    const effectiveProjectId = isBound ? ctx.boundProjectId : overrideProjectId;
 
     // Get workspace color for styling
-    const workspaceColor = activeWorkspaceId
-        ? BUILT_IN_WORKSPACES.find((w) => w.id === activeWorkspaceId)?.color
+    const workspaceColor = ctx.workspaceId
+        ? BUILT_IN_WORKSPACES.find((w) => w.id === ctx.workspaceId)?.color
         : null;
 
     // Get color classes using lookup (ensures Tailwind can detect classes)

--- a/frontend/src/workspace/WorkspaceContext.tsx
+++ b/frontend/src/workspace/WorkspaceContext.tsx
@@ -29,6 +29,8 @@ export interface WorkspaceContextValue {
     scope: WorkspaceScope | null;
     /** What center-workspace should display */
     contentType: CenterContentType;
+    /** Content types this workspace can display. Null = no restriction. */
+    ownedContentTypes: CenterContentType[] | null;
 }
 
 const WorkspaceContext = createContext<WorkspaceContextValue | null>(null);
@@ -63,11 +65,13 @@ export function WorkspaceContextProvider({ children }: WorkspaceContextProviderP
     const boundPanelIds = useWorkspaceStore((s) => s.boundPanelIds);
     const contentType = useUIStore((s) => s.centerContentType);
 
-    const scope = useMemo(() => {
-        if (!workspaceId) return null;
-        const preset = BUILT_IN_WORKSPACES.find((w) => w.id === workspaceId);
-        return preset?.scope ?? null;
-    }, [workspaceId]);
+    const preset = useMemo(
+        () => workspaceId ? BUILT_IN_WORKSPACES.find((w) => w.id === workspaceId) ?? null : null,
+        [workspaceId],
+    );
+
+    const scope = preset?.scope ?? null;
+    const ownedContentTypes = preset?.ownedContentTypes ?? null;
 
     const isBound = useMemo(
         () => (panelId: string) => boundPanelIds.has(panelId),
@@ -82,8 +86,9 @@ export function WorkspaceContextProvider({ children }: WorkspaceContextProviderP
             isBound,
             scope,
             contentType,
+            ownedContentTypes,
         }),
-        [workspaceId, subviewId, boundProjectId, isBound, scope, contentType],
+        [workspaceId, subviewId, boundProjectId, isBound, scope, contentType, ownedContentTypes],
     );
 
     return <WorkspaceContext.Provider value={value}>{children}</WorkspaceContext.Provider>;

--- a/frontend/src/workspace/workspacePresets.ts
+++ b/frontend/src/workspace/workspacePresets.ts
@@ -36,6 +36,7 @@ export const BUILT_IN_WORKSPACES: WorkspacePreset[] = [
         color: 'pink',
         scope: 'global',
         isBuiltIn: true,
+        ownedContentTypes: ['intake'],
         panels: [
             { panelId: 'center-workspace', contentType: 'intake', position: 'center' },
         ],
@@ -56,6 +57,7 @@ export const BUILT_IN_WORKSPACES: WorkspacePreset[] = [
         color: 'blue',
         scope: 'project',
         isBuiltIn: true,
+        ownedContentTypes: ['projects'],
         panels: [
             { panelId: 'center-workspace', contentType: 'projects', viewMode: 'workflow', position: 'center' },
             { panelId: 'selection-inspector', position: 'right', bound: true },
@@ -94,6 +96,7 @@ export const BUILT_IN_WORKSPACES: WorkspacePreset[] = [
         color: 'green',
         scope: 'project',
         isBuiltIn: true,
+        ownedContentTypes: ['projects'],
         panels: [
             { panelId: 'center-workspace', contentType: 'projects', viewMode: 'workflow', position: 'center' },
             { panelId: 'selection-inspector', position: 'right', bound: true },
@@ -127,6 +130,7 @@ export const BUILT_IN_WORKSPACES: WorkspacePreset[] = [
         color: 'purple',
         scope: 'subprocess',
         isBuiltIn: true,
+        ownedContentTypes: ['projects'],
         panels: [
             { panelId: 'center-workspace', contentType: 'projects', viewMode: 'log', position: 'center' },
             { panelId: 'selection-inspector', position: 'right', bound: true },
@@ -149,6 +153,7 @@ export const BUILT_IN_WORKSPACES: WorkspacePreset[] = [
         color: 'orange',
         scope: 'project',
         isBuiltIn: true,
+        ownedContentTypes: ['export'],
         panels: [
             { panelId: 'center-workspace', contentType: 'export', position: 'center' },
         ],
@@ -169,6 +174,7 @@ export const BUILT_IN_WORKSPACES: WorkspacePreset[] = [
         color: 'amber',
         scope: 'global',
         isBuiltIn: true,
+        ownedContentTypes: ['projects', 'mail', 'calendar', 'finance', 'polls', 'artcollector'],
         panels: [
             { panelId: 'project-panel', position: 'center', bound: true },
             { panelId: 'mail-panel', position: 'right' },


### PR DESCRIPTION
## **User description**
## Summary by Sourcery

Add workspace-owned content type metadata and migrate project panel to consume workspace context instead of accessing workspace store directly.

New Features:
- Track which center content types each workspace owns via an optional ownedContentTypes field on workspace presets and workspace context.

Enhancements:
- Expose preset-derived scope and owned content types through WorkspaceContext for consumers.
- Update ProjectPanelContent to use WorkspaceContext for binding state, workspace identification, and styling instead of reading directly from the workspace store.

Documentation:
- Document the new ownedContentTypes field on workspace presets and workspace context.


___

## **CodeAnt-AI Description**
Make panels consume WorkspaceContext and add workspace-owned center content types

### What Changed
- Project panel now uses the active workspace context for whether it’s bound, which project it shows when bound, and which workspace accent color to display
- Workspaces can declare which center-area content types they own; the app exposes those owned content types through the workspace context so center routing and views can validate/show only allowed content
- Workspace provider now derives workspace scope and owned content types from presets and includes them in the context consumers read

### Impact
`✅ Consistent panel binding and project display`
`✅ Center workspace only shows workspace-approved content types`
`✅ Consistent workspace color and styling for bound panels`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #421**
  * **PR #422**
    * **PR #423** 👈
      * **PR #424**
        * **PR #425**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->