### PR TITLE
feat: add CenterView routing ownership to workspaces

### DIFF
--- a/frontend/src/ui/workspace/CenterContentRouter.tsx
+++ b/frontend/src/ui/workspace/CenterContentRouter.tsx
@@ -6,9 +6,14 @@
  *
  * GUARDRAIL: This component's identity never changes.
  * Only the internal renderer switches based on uiStore.centerContentType.
+ *
+ * When a workspace declares ownedContentTypes, the router validates and
+ * redirects to the workspace's default content type on mismatch.
  */
 
+import { useEffect } from 'react';
 import { useUIStore } from '../../stores/uiStore';
+import { useWorkspaceContextOptional } from '../../workspace/WorkspaceContext';
 import { ProjectContentAdapter } from './ProjectContentAdapter';
 import {
     ArtCollectorContent,
@@ -22,6 +27,17 @@ import {
 
 export function CenterContentRouter() {
     const centerContentType = useUIStore((s) => s.centerContentType);
+    const setCenterContentType = useUIStore((s) => s.setCenterContentType);
+    const wsCtx = useWorkspaceContextOptional();
+
+    // Validate content type against workspace's owned types
+    useEffect(() => {
+        if (!wsCtx?.ownedContentTypes) return;
+        if (!wsCtx.ownedContentTypes.includes(centerContentType)) {
+            // Redirect to workspace's default content type (first in list)
+            setCenterContentType(wsCtx.ownedContentTypes[0]);
+        }
+    }, [centerContentType, wsCtx?.ownedContentTypes, setCenterContentType]);
 
     switch (centerContentType) {
         case 'projects':


### PR DESCRIPTION
## **User description**
## Summary by Sourcery

Enhancements:
- Add a workspace-aware effect in the center content router that redirects to a default owned content type when the current type is not owned by the workspace.


___

## **CodeAnt-AI Description**
**Redirect center view to workspace-owned content when needed**

### What Changed
- When a workspace specifies owned content types, the center view now checks the current center content and, if it's not in the workspace's allowed list, switches the view to the workspace's default content type.
- Users in a workspace will no longer see center content types the workspace does not own; the router automatically navigates to the workspace's first declared owned content type.

### Impact
`✅ Prevents showing non-workspace center content`
`✅ Fewer broken or unexpected center views for workspace members`
`✅ Consistent workspace-specific default landing`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #421**
  * **PR #422**
    * **PR #423**
      * **PR #424** 👈
        * **PR #425**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->