### PR TITLE
feat: consolidate content routing and view modes into workspaceStore

### DIFF
--- a/frontend/src/pages/FieldsPage.tsx
+++ b/frontend/src/pages/FieldsPage.tsx
@@ -15,7 +15,8 @@ import { useState, useEffect } from 'react';
 
 import type { FieldDescriptor } from '@autoart/shared';
 
-import { useUIStore, isFieldsViewMode } from '../stores/uiStore';
+import { useUIStore } from '../stores/uiStore';
+import { useWorkspaceStore } from '../stores/workspaceStore';
 import { ResizeHandle } from '@autoart/ui';
 import { FieldsMillerColumnsView } from '../ui/composites/FieldsMillerColumnsView';
 import { Header } from '../ui/layout/Header';
@@ -25,17 +26,19 @@ import { FieldInstancesReview } from '../ui/semantic/FieldInstancesReview';
 
 
 export function FieldsPage() {
-    const { viewMode, setViewMode, openOverlay } = useUIStore();
+    const { openOverlay } = useUIStore();
+    const fieldsViewMode = useWorkspaceStore((s) => s.fieldsViewMode);
+    const setFieldsViewMode = useWorkspaceStore((s) => s.setFieldsViewMode);
     const [sidebarWidth, setSidebarWidth] = useState(600);
     const [selectedField, setSelectedField] = useState<FieldDescriptor | null>(null);
     const [activeTab, setActiveTab] = useState<RegistryTab>('definitions');
 
     // Ensure valid view mode on mount
     useEffect(() => {
-        if (!isFieldsViewMode(viewMode)) {
-            setViewMode('browse');
+        if (fieldsViewMode !== 'browse' && fieldsViewMode !== 'aggregate') {
+            setFieldsViewMode('browse');
         }
-    }, [viewMode, setViewMode]);
+    }, [fieldsViewMode, setFieldsViewMode]);
 
     const handleCreateField = () => {
         openOverlay('add-field', {});

--- a/frontend/src/pages/RecordsPage.tsx
+++ b/frontend/src/pages/RecordsPage.tsx
@@ -13,7 +13,8 @@
 import { Database } from 'lucide-react';
 import { useCallback, useState, useEffect } from 'react';
 
-import { useUIStore, isRecordsViewMode } from '../stores/uiStore';
+import { useUIStore } from '../stores/uiStore';
+import { useWorkspaceStore } from '../stores/workspaceStore';
 import { ResizeHandle } from '@autoart/ui';
 import { SelectionInspector } from '../ui/composites';
 import { RecordView } from '../ui/composites/RecordView';
@@ -21,17 +22,19 @@ import { Header } from '../ui/layout/Header';
 import { RegistryPageHeader, DefinitionListSidebar, type RegistryTab } from '../ui/registry';
 
 export function RecordsPage() {
-  const { inspectorWidth, setInspectorWidth, viewMode, setViewMode, openOverlay } = useUIStore();
+  const { inspectorWidth, setInspectorWidth, openOverlay } = useUIStore();
+  const recordsViewMode = useWorkspaceStore((s) => s.recordsViewMode);
+  const setRecordsViewMode = useWorkspaceStore((s) => s.setRecordsViewMode);
   const [sidebarWidth, setSidebarWidth] = useState(260);
   const [selectedDefinitionId, setSelectedDefinitionId] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<RegistryTab>('instances');
 
   // Ensure we're using a valid RecordsViewMode when on this page
   useEffect(() => {
-    if (!isRecordsViewMode(viewMode)) {
-      setViewMode('list');
+    if (recordsViewMode !== 'list' && recordsViewMode !== 'ingest') {
+      setRecordsViewMode('list');
     }
-  }, [viewMode, setViewMode]);
+  }, [recordsViewMode, setRecordsViewMode]);
 
   const handleSidebarResize = useCallback(
     (delta: number) => {

--- a/frontend/src/types/workspace.ts
+++ b/frontend/src/types/workspace.ts
@@ -7,7 +7,20 @@
 
 import type { LucideIcon } from 'lucide-react';
 import type { PanelId } from '../workspace/panelRegistry';
-import type { CenterContentType } from '../stores/uiStore';
+
+/**
+ * Content type for center-workspace panel.
+ * Determines what content is displayed in the permanent center anchor.
+ */
+export type CenterContentType =
+    | 'projects'      // Project views (workflow, log, columns, list, cards)
+    | 'artcollector'  // Art collection workflow
+    | 'intake'        // Data intake workflow
+    | 'export'        // Export workflow
+    | 'mail'          // Communication
+    | 'calendar'      // Calendar view
+    | 'finance'       // Finance hub (invoices, budgets, expenses)
+    | 'polls';        // Availability polls
 
 /**
  * Scope determines when a workspace is available:

--- a/frontend/src/ui/command-palette/CommandPalette.tsx
+++ b/frontend/src/ui/command-palette/CommandPalette.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react';
 
 import { useUIStore } from '@/stores/uiStore';
+import { useWorkspaceStore } from '@/stores/workspaceStore';
 import { useProjects } from '@/api/hooks/hierarchy';
 import { useRecords } from '@/api/hooks/entities/records';
 import { useAllActions } from '@/api/hooks/actions/actions';
@@ -69,7 +70,7 @@ export function CommandPalette() {
   const inspectAction = useUIStore((s) => s.inspectAction);
   const toggleSidebar = useUIStore((s) => s.toggleSidebar);
   const toggleInspector = useUIStore((s) => s.toggleInspector);
-  const setProjectViewMode = useUIStore((s) => s.setProjectViewMode);
+  const setProjectViewMode = useWorkspaceStore((s) => s.setProjectViewMode);
   const openOverlay = useUIStore((s) => s.openOverlay);
 
   // Generate unique IDs for ARIA

--- a/frontend/src/ui/composites/IngestionView.tsx
+++ b/frontend/src/ui/composites/IngestionView.tsx
@@ -11,7 +11,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 
 import { useIngestionParsers, useIngestionPreview, useRunIngestion } from '../../api/hooks';
 import { useHierarchyStore } from '../../stores/hierarchyStore';
-import { useUIStore } from '../../stores/uiStore';
+import { useWorkspaceStore } from '../../stores/workspaceStore';
 
 interface IngestionViewProps {
     /**
@@ -22,7 +22,7 @@ interface IngestionViewProps {
 
 export function IngestionView({ onImportComplete }: IngestionViewProps) {
     const { selectProject } = useHierarchyStore();
-    const { setViewMode } = useUIStore();
+    const setRecordsViewMode = useWorkspaceStore((s) => s.setRecordsViewMode);
 
     // Data state
     const [rawData, setRawData] = useState('');
@@ -98,16 +98,16 @@ export function IngestionView({ onImportComplete }: IngestionViewProps) {
 
             // Select the new project and switch back to list view
             selectProject(result.projectId);
-            setViewMode('list');
+            setRecordsViewMode('list');
             onImportComplete?.(result.projectId);
         } catch (err) {
             console.error('Import failed:', err);
         }
-    }, [rawData, selectedParser, parserConfig, runImport, selectProject, setViewMode, onImportComplete]);
+    }, [rawData, selectedParser, parserConfig, runImport, selectProject, setRecordsViewMode, onImportComplete]);
 
     const handleCancel = useCallback(() => {
-        setViewMode('list');
-    }, [setViewMode]);
+        setRecordsViewMode('list');
+    }, [setRecordsViewMode]);
 
     if (parsersLoading) {
         return (

--- a/frontend/src/ui/layout/Header.tsx
+++ b/frontend/src/ui/layout/Header.tsx
@@ -20,8 +20,8 @@ import { useHierarchyStore } from '../../stores/hierarchyStore';
 import {
   useUIStore,
   FIELDS_VIEW_MODE_LABELS,
-  type CenterContentType,
 } from '../../stores/uiStore';
+import type { CenterContentType } from '../../types/workspace';
 import { useCollectionStore } from '../../stores';
 import { useCollectionModeOptional } from '../../workflows/export/context/CollectionModeProvider';
 import { useWorkspaceStore, useOpenPanelIds } from '../../stores/workspaceStore';
@@ -37,7 +37,10 @@ export function Header() {
   const { data: projects } = useProjects();
   const { data: currentUser } = useCurrentUser();
   const { getNode: _getNode } = useHierarchyStore();
-  const { fieldsViewMode, setFieldsViewMode, openOverlay, setCenterContentType } = useUIStore();
+  const { openOverlay } = useUIStore();
+  const fieldsViewMode = useWorkspaceStore((s) => s.fieldsViewMode);
+  const setFieldsViewMode = useWorkspaceStore((s) => s.setFieldsViewMode);
+  const setCenterContentType = useWorkspaceStore((s) => s.setCenterContentType);
   const collectionMode = useCollectionModeOptional();
 
   const { openPanel, setBoundProject } = useWorkspaceStore();

--- a/frontend/src/ui/panels/FieldsPanel.tsx
+++ b/frontend/src/ui/panels/FieldsPanel.tsx
@@ -11,6 +11,7 @@ import { useState, useEffect } from 'react';
 import type { FieldDescriptor } from '@autoart/shared';
 
 import { useUIStore } from '../../stores/uiStore';
+import { useWorkspaceStore } from '../../stores/workspaceStore';
 import { useCollectionModeOptional } from '../../workflows/export/context/CollectionModeProvider';
 import { ResizeHandle, SegmentedControl } from '@autoart/ui';
 import { FieldsMillerColumnsView } from '../composites/FieldsMillerColumnsView';
@@ -25,7 +26,8 @@ const TAB_DATA = [
 ];
 
 export function FieldsPanel() {
-    const { setFieldsViewMode, openOverlay } = useUIStore();
+    const setFieldsViewMode = useWorkspaceStore((s) => s.setFieldsViewMode);
+    const { openOverlay } = useUIStore();
     const collectionMode = useCollectionModeOptional();
     const [sidebarWidth, setSidebarWidth] = useState(300);
     const [selectedField, setSelectedField] = useState<FieldDescriptor | null>(null);

--- a/frontend/src/ui/workspace/CenterContentRouter.tsx
+++ b/frontend/src/ui/workspace/CenterContentRouter.tsx
@@ -5,14 +5,14 @@
  * This is the permanent center anchor that can display different content types.
  *
  * GUARDRAIL: This component's identity never changes.
- * Only the internal renderer switches based on uiStore.centerContentType.
+ * Only the internal renderer switches based on workspaceStore.centerContentType.
  *
  * When a workspace declares ownedContentTypes, the router validates and
  * redirects to the workspace's default content type on mismatch.
  */
 
 import { useEffect } from 'react';
-import { useUIStore } from '../../stores/uiStore';
+import { useWorkspaceStore } from '../../stores/workspaceStore';
 import { useWorkspaceContextOptional } from '../../workspace/WorkspaceContext';
 import { ProjectContentAdapter } from './ProjectContentAdapter';
 import {
@@ -26,8 +26,8 @@ import {
 } from './content';
 
 export function CenterContentRouter() {
-    const centerContentType = useUIStore((s) => s.centerContentType);
-    const setCenterContentType = useUIStore((s) => s.setCenterContentType);
+    const centerContentType = useWorkspaceStore((s) => s.centerContentType);
+    const setCenterContentType = useWorkspaceStore((s) => s.setCenterContentType);
     const wsCtx = useWorkspaceContextOptional();
 
     // Validate content type against workspace's owned types

--- a/frontend/src/ui/workspace/ProjectContentAdapter.tsx
+++ b/frontend/src/ui/workspace/ProjectContentAdapter.tsx
@@ -10,7 +10,8 @@
  */
 
 import { SegmentedControl } from '@autoart/ui';
-import { useUIStore, useUIPanels, PROJECT_VIEW_MODE_LABELS } from '../../stores/uiStore';
+import { useUIPanels, PROJECT_VIEW_MODE_LABELS } from '../../stores/uiStore';
+import { useWorkspaceStore } from '../../stores/workspaceStore';
 import type { ProjectViewMode } from '@autoart/shared';
 
 import { ActionListView } from '../layout/ActionListView';
@@ -27,7 +28,8 @@ const VIEW_MODE_DATA = Object.entries(PROJECT_VIEW_MODE_LABELS).map(([value, lab
 
 export function ProjectContentAdapter() {
     const panels = useUIPanels();
-    const { projectViewMode, setProjectViewMode } = useUIStore();
+    const projectViewMode = useWorkspaceStore((s) => s.projectViewMode);
+    const setProjectViewMode = useWorkspaceStore((s) => s.setProjectViewMode);
 
     // Render the active subview based on workspace mode
     const renderContent = () => {

--- a/frontend/src/workspace/WorkspaceContext.tsx
+++ b/frontend/src/workspace/WorkspaceContext.tsx
@@ -10,10 +10,8 @@
  */
 
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
-import type { WorkspaceScope } from '../types/workspace';
-import type { CenterContentType } from '../stores/uiStore';
+import type { WorkspaceScope, CenterContentType } from '../types/workspace';
 import { useWorkspaceStore } from '../stores/workspaceStore';
-import { useUIStore } from '../stores/uiStore';
 import { BUILT_IN_WORKSPACES } from './workspacePresets';
 
 export interface WorkspaceContextValue {
@@ -63,7 +61,7 @@ export function WorkspaceContextProvider({ children }: WorkspaceContextProviderP
     const subviewId = useWorkspaceStore((s) => s.activeSubviewId);
     const boundProjectId = useWorkspaceStore((s) => s.boundProjectId);
     const boundPanelIds = useWorkspaceStore((s) => s.boundPanelIds);
-    const contentType = useUIStore((s) => s.centerContentType);
+    const contentType = useWorkspaceStore((s) => s.centerContentType);
 
     const preset = useMemo(
         () => workspaceId ? BUILT_IN_WORKSPACES.find((w) => w.id === workspaceId) ?? null : null,


### PR DESCRIPTION
## **User description**
Move centerContentType, projectViewMode, fieldsViewMode, and
recordsViewMode from uiStore to workspaceStore. Eliminates cross-store
calls in applyWorkspace() — workspace presets now own their content
and view state directly. Bump uiStore v5→v6, workspaceStore v3→v4
with migration logic for both stores.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #426** 👈
  * **PR #427**
    * **PR #428**
      * **PR #429**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
**Move center workspace content routing and panel-specific view modes into workspace state**

### What Changed
- Center content type and per-panel view modes (project, fields, records) now live in the workspace store instead of the global UI store; UI components read and update these values from the active workspace state.
- Workspace presets now own and restore their center content and view-mode settings when a workspace is applied; switching workspaces applies the workspace's configured content and view-mode.
- Persisted store formats and migration logic updated: uiStore persistence no longer contains center-content and view-mode fields, and workspaceStore persists and restores those fields; layout version bumped to reflect the move.
- Various UI components (pages, panels, command palette, command actions) now use workspace-scoped view modes, preventing cross-store inconsistencies when changing views.

### Impact
`✅ Consistent workspace-specific content routing`
`✅ Fewer layout/view-mode mismatches when switching workspaces`
`✅ Persistent per-workspace view modes restored on load`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

## Summary by Sourcery

Move center workspace content routing and per-panel view modes from the global UI store into the workspace store so workspaces own their content and view state, with updated persistence and layout versions.

New Features:
- Add workspace-scoped state for center content type and per-panel view modes (project, fields, records), including selectors and setters for consumers.

Enhancements:
- Adjust workspace application and capture logic so workspace presets read, store, and restore center content and view modes directly from workspace state.
- Update UI components (pages, panels, header, center router, command palette) to use workspaceStore for content routing and view modes instead of uiStore.
- Extract CenterContentType into shared workspace types for clearer ownership and reuse.