### PR TITLE
feat: add rename and context menu for custom workspaces

### DIFF
--- a/frontend/src/stores/workspaceStore.ts
+++ b/frontend/src/stores/workspaceStore.ts
@@ -123,6 +123,7 @@ interface WorkspaceState {
     applyWorkspace: (workspaceId: string, subviewId?: string) => void;
     saveCurrentAsWorkspace: (name: string, options?: { color?: string; parentWorkspaceId?: string }) => void;
     updateCustomWorkspace: (id: string) => void;
+    renameCustomWorkspace: (id: string, newName: string) => void;
     deleteCustomWorkspace: (id: string) => void;
     duplicateSubview: (parentWorkspaceId: string, subviewId: string, name: string, color?: string) => void;
     duplicateCustomWorkspace: (id: string) => void;
@@ -481,6 +482,31 @@ export const useWorkspaceStore = create<WorkspaceState>()(
                             : w
                     ),
                     workspaceModified: false,
+                });
+            },
+
+            renameCustomWorkspace: (id: string, newName: string) => {
+                const state = get();
+                const workspace = state.customWorkspaces.find(w => w.id === id);
+                if (!workspace) {
+                    console.warn(`Cannot rename workspace: ${id} (not found)`);
+                    return;
+                }
+                const trimmed = newName.trim();
+                if (!trimmed) return;
+                // Check name uniqueness across all workspaces
+                const allNames = [
+                    ...BUILT_IN_WORKSPACES.map(w => w.label.toLowerCase()),
+                    ...state.customWorkspaces.filter(w => w.id !== id).map(w => w.label.toLowerCase()),
+                ];
+                if (allNames.includes(trimmed.toLowerCase())) {
+                    console.warn(`Cannot rename workspace: name "${trimmed}" already exists`);
+                    return;
+                }
+                set({
+                    customWorkspaces: state.customWorkspaces.map(w =>
+                        w.id === id ? { ...w, label: trimmed } : w
+                    ),
                 });
             },
 


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #426**
  * **PR #427**
    * **PR #428** 👈
      * **PR #429**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
**Allow renaming custom workspaces from the workspace dropdown**

### What Changed
- Users can rename any custom workspace via a new "Rename" action in each custom workspace's menu item; this opens a small modal to edit the name.
- The rename modal is keyboard accessible (focus/select on open, Enter to confirm) and disables the Rename button if the name is empty or unchanged.
- Renames are trimmed and blocked if the chosen name already exists among built-in or other custom workspaces; invalid rename attempts are ignored with a console warning.
- Existing duplicate and delete actions remain available on custom workspace items.

### Impact
`✅ Can rename custom workspaces from the dropdown`
`✅ Prevents duplicate workspace names`
`✅ Keyboard-accessible rename flow`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

## Summary by Sourcery

Add support for renaming custom workspaces from the workspace dropdown, including a dedicated rename dialog and store-level name validation.

New Features:
- Allow users to rename custom workspaces from the workspace dropdown via an inline action that opens a rename dialog.

Enhancements:
- Add a keyboard-accessible rename dialog with validation that prevents empty or duplicate workspace names across built-in and custom workspaces.