### PR TITLE
feat: phase 2.2 - replace entityType string checks with resolveEntityKind

### DIFF
--- a/backend/src/modules/imports/types.ts
+++ b/backend/src/modules/imports/types.ts
@@ -5,7 +5,7 @@
  * Includes classification support for two-phase import gate.
  */
 
-import type { ClassificationOutcome } from '@autoart/shared';
+import type { ClassificationOutcome, EntityKind } from '@autoart/shared';
 
 // ============================================================================
 // CLASSIFICATION TYPES
@@ -124,8 +124,8 @@ export interface ImportPlanItem {
     /** Parent container temp ID (optional for connector imports) */
     parentTempId?: string;
     metadata: Record<string, unknown>;
-    /** Entity type inferred from source (project, process, stage, subprocess, action, record, template) */
-    entityType?: 'project' | 'process' | 'stage' | 'subprocess' | 'action' | 'record' | 'template';
+    /** Entity kind resolved from source data (project, process, stage, subprocess, action, record, template) */
+    entityType?: EntityKind;
     /** Planned action for execution (optional for connector imports) */
     plannedAction?: {
         type: string;

--- a/frontend/src/api/hooks/imports.ts
+++ b/frontend/src/api/hooks/imports.ts
@@ -4,6 +4,7 @@
  * React Query hooks for import sessions API.
  */
 
+import type { EntityKind } from '@autoart/shared';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { api } from '../client';
@@ -35,8 +36,8 @@ export interface ImportPlanItem {
     /** Parent container or item temp ID (optional for top-level items) */
     parentTempId?: string;
     metadata: Record<string, unknown>;
-    /** Entity type inferred from source (project, process, stage, subprocess, action, record, template) */
-    entityType?: 'project' | 'process' | 'stage' | 'subprocess' | 'action' | 'record' | 'template';
+    /** Entity kind resolved from source data */
+    entityType?: EntityKind;
     /** Planned action for execution (optional for connector imports) */
     plannedAction?: {
         type: string;

--- a/frontend/src/ui/composites/DataTableImport.tsx
+++ b/frontend/src/ui/composites/DataTableImport.tsx
@@ -22,6 +22,7 @@
  * - Wrapper discovers columns from fieldRecordings
  */
 
+import { resolveEntityKind, type EntityKind } from '@autoart/shared';
 import { clsx } from 'clsx';
 import { ChevronRight, ChevronDown, Folder, FileText, Box, AlertCircle, CheckCircle2 } from 'lucide-react';
 import { useMemo, useCallback } from 'react';
@@ -234,10 +235,10 @@ function ClassificationBadge({ classification }: { classification: ItemClassific
     );
 }
 
-function EntityTypeBadge({ entityType }: { entityType: string }) {
+function EntityKindBadge({ kind }: { kind: EntityKind }) {
     return (
         <span className="text-[10px] font-semibold uppercase text-ws-muted bg-slate-100 px-1.5 py-0.5 rounded">
-            {entityType}
+            {kind}
         </span>
     );
 }
@@ -307,9 +308,9 @@ export function DataTableImport({
                 const meta = getImportPlanMeta(row);
                 const node = getImportPlanNode(row);
 
-                // Icon based on node/entity type
+                // Icon based on entity kind
                 const Icon = meta.nodeType === 'container'
-                    ? (meta.entityType === 'project' ? Folder : meta.entityType === 'process' ? Box : Folder)
+                    ? (meta.entityKind === 'project' ? Folder : meta.entityKind === 'process' ? Box : Folder)
                     : FileText;
 
                 return (
@@ -350,7 +351,7 @@ export function DataTableImport({
             align: 'center' as const,
             cell: (row) => {
                 const meta = getImportPlanMeta(row);
-                return <EntityTypeBadge entityType={meta.entityType} />;
+                return <EntityKindBadge kind={meta.entityKind} />;
             },
         });
 
@@ -595,7 +596,7 @@ function NestedLevel({
 
                             {/* Type cell */}
                             <div className="w-16 px-2 py-2 text-center">
-                                <EntityTypeBadge entityType={item.entityType || 'action'} />
+                                <EntityKindBadge kind={resolveEntityKind(item)} />
                             </div>
 
                             {/* Field cells */}

--- a/frontend/src/ui/composites/ImportItemDetailsView.tsx
+++ b/frontend/src/ui/composites/ImportItemDetailsView.tsx
@@ -11,6 +11,7 @@
  * - Validation issues
  */
 
+import { resolveEntityKind } from '@autoart/shared';
 import { Tag, AlertCircle, List, CheckCircle2, User, Calendar, Hash, FileText } from 'lucide-react';
 
 import { useUIStore } from '../../stores/uiStore';
@@ -360,9 +361,7 @@ export function ImportItemDetailsView({ itemId, tab, plan: propPlan }: ImportIte
                     </Text>
                     <div className="mt-3 flex items-center gap-2">
                         <Badge variant="neutral" size="sm" className="uppercase text-[10px] font-semibold">
-                            {isContainer
-                                ? (selectedItem as { type?: string }).type || 'container'
-                                : (selectedItem as { entityType?: string }).entityType || 'item'}
+                            {resolveEntityKind(selectedItem as unknown as Record<string, unknown>)}
                         </Badge>
                         {classification && (
                             <Badge

--- a/shared/src/domain/entity-kind.ts
+++ b/shared/src/domain/entity-kind.ts
@@ -1,0 +1,183 @@
+/**
+ * Entity Kind Resolver
+ *
+ * Unified type discrimination for AutoArt entities.
+ * Replaces scattered entityType string checks with a single resolver
+ * that derives kind from structural relationships (hierarchy type,
+ * definition kind, parent context).
+ *
+ * Resolution order:
+ * 1. HierarchyNode.type → return directly (project, process, stage, subprocess, template)
+ * 2. RecordDefinition.kind / definition_kind → map to entity kind
+ * 3. DataRecord.definition_id + definitions lookup → recurse on definition's kind
+ * 4. ImportPlanItem.entityType → validate and return
+ * 5. Fallback → 'unknown'
+ */
+
+import type { NodeType, DefinitionKind } from '../schemas/enums.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical entity kinds in AutoArt.
+ *
+ * Maps 1:1 to hierarchy NodeType for structural entities.
+ * 'record' and 'action' are the two user-facing data entity kinds
+ * (action_arrangement collapses to 'action' — the domain concept).
+ * Container definitions resolve to their specific hierarchy type via name lookup.
+ */
+export type EntityKind =
+  | 'project'
+  | 'process'
+  | 'stage'
+  | 'subprocess'
+  | 'template'
+  | 'record'
+  | 'action'
+  | 'unknown';
+
+const ENTITY_KINDS: ReadonlySet<string> = new Set<EntityKind>([
+  'project',
+  'process',
+  'stage',
+  'subprocess',
+  'template',
+  'record',
+  'action',
+  'unknown',
+]);
+
+const NODE_TYPES: ReadonlySet<string> = new Set<NodeType>([
+  'project',
+  'process',
+  'stage',
+  'subprocess',
+  'template',
+]);
+
+/**
+ * Minimal definition shape accepted by the resolver.
+ * Tolerates both `kind` (Zod schema) and `definition_kind` (raw API column).
+ */
+export interface DefinitionLike {
+  id: string;
+  kind?: string;
+  definition_kind?: string;
+  name?: string;
+}
+
+/**
+ * Input union for resolveEntityKind.
+ * Accepts any object that carries enough signal to derive entity kind.
+ */
+export type EntityKindInput =
+  | { type: NodeType }                              // HierarchyNode
+  | { definition_id: string }                       // DataRecord
+  | { entityType?: string; parentTempId?: string }  // ImportPlanItem
+  | { kind?: DefinitionKind }                       // RecordDefinition (Zod-parsed)
+  | { definition_kind?: DefinitionKind }            // RecordDefinition (raw API)
+  | Record<string, unknown>;                        // catch-all for partial objects
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a definition's kind (+ optional name for containers) to EntityKind.
+ */
+export function definitionKindToEntityKind(
+  kind: string,
+  name?: string,
+): EntityKind {
+  switch (kind) {
+    case 'record':
+      return 'record';
+    case 'action_arrangement':
+      return 'action';
+    case 'container': {
+      if (!name) return 'subprocess'; // safe default for unnamed containers
+      const lower = name.toLowerCase();
+      if (lower === 'process') return 'process';
+      if (lower === 'stage') return 'stage';
+      if (lower === 'subprocess') return 'subprocess';
+      return 'subprocess'; // unknown container name → default
+    }
+    default:
+      return 'unknown';
+  }
+}
+
+/**
+ * Type guard: is the value a valid EntityKind?
+ */
+export function isEntityKind(value: string): value is EntityKind {
+  return ENTITY_KINDS.has(value);
+}
+
+// ---------------------------------------------------------------------------
+// Resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the canonical EntityKind for an object.
+ *
+ * @param item   - Any entity-like object (hierarchy node, data record,
+ *                 record definition, import plan item)
+ * @param definitions - Optional definitions array for definition_id lookup.
+ *                      Required when resolving DataRecords.
+ */
+export function resolveEntityKind(
+  item: EntityKindInput,
+  definitions?: ReadonlyArray<DefinitionLike>,
+): EntityKind {
+  const obj = item as Record<string, unknown>;
+
+  // 1. HierarchyNode — has `type` that matches a NodeType
+  if (typeof obj.type === 'string' && NODE_TYPES.has(obj.type)) {
+    return obj.type as EntityKind;
+  }
+
+  // 2. RecordDefinition — has `kind` (Zod-parsed)
+  if (typeof obj.kind === 'string' && isDefinitionKind(obj.kind)) {
+    return definitionKindToEntityKind(obj.kind, obj.name as string | undefined);
+  }
+
+  // 3. RecordDefinition — has `definition_kind` (raw API column)
+  if (typeof obj.definition_kind === 'string' && isDefinitionKind(obj.definition_kind)) {
+    return definitionKindToEntityKind(obj.definition_kind, obj.name as string | undefined);
+  }
+
+  // 4. DataRecord — has `definition_id`, look up in provided definitions
+  if (typeof obj.definition_id === 'string' && definitions) {
+    const def = definitions.find((d) => d.id === obj.definition_id);
+    if (def) {
+      const kind = def.kind ?? def.definition_kind;
+      if (kind) {
+        return definitionKindToEntityKind(kind, def.name);
+      }
+    }
+  }
+
+  // 5. ImportPlanItem — has `entityType`
+  if (typeof obj.entityType === 'string') {
+    return isEntityKind(obj.entityType) ? obj.entityType : 'unknown';
+  }
+
+  return 'unknown';
+}
+
+// ---------------------------------------------------------------------------
+// Internal
+// ---------------------------------------------------------------------------
+
+const DEFINITION_KINDS: ReadonlySet<string> = new Set<DefinitionKind>([
+  'record',
+  'action_arrangement',
+  'container',
+]);
+
+function isDefinitionKind(value: string): value is DefinitionKind {
+  return DEFINITION_KINDS.has(value);
+}

--- a/shared/src/domain/index.ts
+++ b/shared/src/domain/index.ts
@@ -83,3 +83,17 @@ export {
     groupViewModelsByCategory,
     createEmptyFieldViewModel,
 } from './fieldViewModel.js';
+
+// ==================== ENTITY KIND ====================
+
+export type {
+    EntityKind,
+    EntityKindInput,
+    DefinitionLike,
+} from './entity-kind.js';
+
+export {
+    resolveEntityKind,
+    definitionKindToEntityKind,
+    isEntityKind,
+} from './entity-kind.js';

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -36,6 +36,9 @@ export type {
   Reference,
   FieldViewModel,
   EntityContext,
+  EntityKind,
+  EntityKindInput,
+  DefinitionLike,
 } from './domain/index.js';
 
 export {
@@ -71,6 +74,10 @@ export {
   filterVisibleViewModels,
   groupViewModelsByCategory,
   createEmptyFieldViewModel,
+  // Entity kind resolver
+  resolveEntityKind,
+  definitionKindToEntityKind,
+  isEntityKind,
 } from './domain/index.js';
 
 export type { BuildFieldViewModelOptions } from './domain/index.js';

--- a/shared/src/schemas/enums.ts
+++ b/shared/src/schemas/enums.ts
@@ -9,6 +9,15 @@ export const NodeTypeSchema = z.enum(['project', 'process', 'stage', 'subprocess
 export type NodeType = z.infer<typeof NodeTypeSchema>;
 
 /**
+ * Definition kind enum - discriminator for record definition types
+ * - record: Standard data records
+ * - action_arrangement: Action/workflow templates
+ * - container: Hierarchy container definitions (Process, Stage, Subprocess)
+ */
+export const DefinitionKindSchema = z.enum(['record', 'action_arrangement', 'container']);
+export type DefinitionKind = z.infer<typeof DefinitionKindSchema>;
+
+/**
  * Reference mode enum - static vs dynamic references
  * Used for input when creating/updating references
  */

--- a/shared/src/schemas/index.ts
+++ b/shared/src/schemas/index.ts
@@ -8,6 +8,7 @@
 // ==================== ENUMS ====================
 export {
     NodeTypeSchema,
+    DefinitionKindSchema,
     RefModeSchema,
     ReferenceStatusSchema,
     FieldTypeSchema,
@@ -31,6 +32,7 @@ export {
     WORKSPACE_THEME_LABELS,
     WORKSPACE_THEME_DESCRIPTIONS,
     type NodeType,
+    type DefinitionKind,
     type RefMode,
     type ReferenceStatus,
     type FieldType,

--- a/shared/src/schemas/records.ts
+++ b/shared/src/schemas/records.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { FieldTypeSchema } from './enums.js';
+import { DefinitionKindSchema, FieldTypeSchema } from './enums.js';
 
 /**
  * Status Option Config Schema
@@ -129,7 +129,8 @@ export const RecordDefinitionSchema = z.object({
   project_id: z.string().uuid().nullable(), // If set, belongs to project's template library
   is_template: z.boolean(),
   is_system: z.boolean(), // System definitions (Task, Subtask, etc.) - cannot be deleted
-  kind: z.enum(['record', 'action_arrangement', 'container']).default('record'), // Discriminator for definition types
+  kind: DefinitionKindSchema.default('record'), // Discriminator for definition types
+  definition_kind: DefinitionKindSchema.optional(), // Alias — raw column name from API selectAll()
   parent_definition_id: z.string().uuid().nullable(), // For hierarchical types (e.g., Subtask under Task)
   clone_excluded: z.boolean(),
   pinned: z.boolean(),


### PR DESCRIPTION
## **User description**
## Summary by Sourcery

Standardize entity discrimination across imports and shared domain by introducing a centralized EntityKind resolver and updating import pipelines and UI to rely on it instead of ad-hoc entityType strings.

New Features:
- Add a shared EntityKind type system and resolver utilities to derive canonical entity kinds from hierarchy nodes, record definitions, data records, and import items.

Bug Fixes:
- Handle additional container-like entity kinds (process, subprocess) in connector classification as internal work items and treat unknown kinds explicitly.

Enhancements:
- Refine import execution and classification logic to use resolveEntityKind for record/template/item handling and diagnostics instead of raw entityType checks.
- Update import plan frontend models, table views, and item details UI to carry and display EntityKind rather than loosely-typed entityType strings.
- Extend shared schemas with a DefinitionKind enum and wire it into record definition schemas and exports to support consistent definition-to-entity kind mapping.

Documentation:
- Clarify comments around definition kind semantics and entity kind resolution within shared schemas and domain utilities.


___

## **CodeAnt-AI Description**
Use centralized EntityKind resolver for import classification, execution, and UI

### What Changed
- Import classification and execution now determine an item's kind via a single resolver instead of ad-hoc entityType strings; classifications, creation rules, and diagnostic logs use the resolved kind.
- Connector imports now treat process and subprocess kinds as internal structural work, record items without schema matches are logged more explicitly, and unknown kinds produce clearer "unknown kind" rationales.
- Frontend displays and tables show the resolved entity kind in badges, icons, and row metadata so import item type is consistent across detail views and table lists.
- Shared package gains a canonical EntityKind type, a resolver that maps definitions/hierarchy to kinds, and a DefinitionKind enum used by record definition schemas.

### Impact
`✅ Clearer import item types in UI`
`✅ Fewer misclassified import items during execution`
`✅ Clearer import diagnostics and logs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #430** 👈
  * **PR #431**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->