### PR TITLE
fix: wire wizard escape hatches

### DIFF
--- a/frontend/src/workflows/import/wizard/MondayImportWizardView.tsx
+++ b/frontend/src/workflows/import/wizard/MondayImportWizardView.tsx
@@ -1,6 +1,6 @@
 
 import { useState, useCallback, useEffect, useMemo } from 'react';
-import { Stack, Card, Text, ProgressBar, Inline } from '@autoart/ui';
+import { Stack, Card, Text, ProgressBar, Inline, Button } from '@autoart/ui';
 
 import { useContextStore } from '../../../stores/contextStore';
 import { ImportContextProvider, type ImportContextValue } from '../context/ImportContextProvider';
@@ -37,7 +37,7 @@ export function MondayImportWizardView({
     session,
     plan,
     onSelectItem,
-    onReset: _onReset,
+    onReset,
     onSessionCreated,
 }: MondayImportWizardViewProps) {
     const [currentStep, setCurrentStep] = useState(1);
@@ -104,8 +104,10 @@ export function MondayImportWizardView({
     const handleBack = useCallback(() => {
         if (currentStep > 1) {
             setCurrentStep((s) => s - 1);
+        } else {
+            onReset();
         }
-    }, [currentStep]);
+    }, [currentStep, onReset]);
 
     return (
         <ImportContextProvider value={contextValue}>
@@ -116,7 +118,10 @@ export function MondayImportWizardView({
                         <Stack gap="sm">
                             <Inline align="center" justify="between">
                                 <Text size="lg" weight="bold">Monday.com Import Wizard</Text>
-                                <Text size="sm" color="muted">Step {currentStep} of {STEPS.length}: {STEPS[currentStep - 1].title}</Text>
+                                <Inline align="center" gap="md">
+                                    <Text size="sm" color="muted">Step {currentStep} of {STEPS.length}: {STEPS[currentStep - 1].title}</Text>
+                                    <Button variant="ghost" size="sm" onClick={onReset}>Cancel Import</Button>
+                                </Inline>
                             </Inline>
                             <ProgressBar value={progress} size="sm" />
                         </Stack>

--- a/frontend/src/workflows/import/wizard/steps/Step1SelectBoards.tsx
+++ b/frontend/src/workflows/import/wizard/steps/Step1SelectBoards.tsx
@@ -21,7 +21,7 @@ interface StepProps {
     onSessionCreated: (session: ImportSession, plan: ImportPlan) => void;
 }
 
-export function Step1SelectBoards({ onNext, onSessionCreated }: StepProps) {
+export function Step1SelectBoards({ onNext, onBack, onSessionCreated }: StepProps) {
     const { data: connections } = useConnections();
     const { data: boards, isLoading, error } = useMondayBoards();
     const { data: projects, isLoading: projectsLoading } = useProjects();
@@ -241,7 +241,8 @@ export function Step1SelectBoards({ onNext, onSessionCreated }: StepProps) {
                 </Inline>
             )}
 
-            <Inline justify="end" className="pt-2">
+            <Inline justify="between" className="pt-2">
+                <Button variant="secondary" onClick={onBack}>Cancel</Button>
                 <Button
                     onClick={handleCreateSession}
                     variant="primary"


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #432** 👈
  * **PR #433**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->

## Summary by Sourcery

Add explicit escape hatches to the Monday.com import wizard so users can cancel and exit the flow from the UI and via the back navigation.

New Features:
- Add a visible Cancel Import button to the Monday.com import wizard header.
- Add a Cancel button to the first step of the Monday.com import wizard to exit the flow.

Enhancements:
- Wire the wizard back navigation to trigger the reset handler when navigating back from the first step.


___

## **CodeAnt-AI Description**
Add visible cancel controls and wire back navigation to exit the Monday.com import wizard

### What Changed
- A "Cancel Import" button is now visible in the wizard header; clicking it exits the import flow.
- The first step footer now shows a "Cancel" button that exits the wizard without creating an import session.
- Using the wizard back action when already on the first step now exits the wizard and triggers the reset behavior.

### Impact
`✅ Can cancel import from header`
`✅ Can cancel import from first step`
`✅ Back navigation exits wizard and clears import state`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
