### PR TITLE
fix: prevent stale plan regeneration from race conditions in column updates

### DIFF
--- a/frontend/src/workflows/import/wizard/steps/Step3Columns.tsx
+++ b/frontend/src/workflows/import/wizard/steps/Step3Columns.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef, useEffect } from 'react';
 import { ChevronDown, AlertTriangle, X } from 'lucide-react';
 import { clsx } from 'clsx';
 import {
@@ -303,6 +303,8 @@ export function Step3Columns({ onNext, onBack, session, onSessionCreated }: Step
     const [isRefreshing, setIsRefreshing] = useState(false);
     const [isPreviewOpen, setIsPreviewOpen] = useState(false);
     const [inflightMutations, setInflightMutations] = useState(0);
+    const inflightRef = useRef(0);
+    useEffect(() => { inflightRef.current = inflightMutations; }, [inflightMutations]);
 
     // Extract board IDs
     const boardIds = useMemo(() => {
@@ -364,10 +366,10 @@ export function Step3Columns({ onNext, onBack, session, onSessionCreated }: Step
         try {
             setIsRefreshing(true);
             // Wait for any in-flight column updates to settle
-            if (inflightMutations > 0) {
+            if (inflightRef.current > 0) {
                 await new Promise<void>(resolve => {
                     const check = () => {
-                        if (inflightMutations <= 0) resolve();
+                        if (inflightRef.current <= 0) resolve();
                         else setTimeout(check, 50);
                     };
                     check();


### PR DESCRIPTION
## **User description**


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #434** 👈
  * **PR #435**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->

## Summary by Sourcery

Synchronize column update mutations with plan regeneration to avoid race conditions and stale data when progressing from the column configuration step, and introduce optimistic updates for Monday board column configs.

Bug Fixes:
- Prevent plan regeneration from running while column update mutations are still in flight, avoiding stale or inconsistent plans.
- Disable navigation to the next step while column updates are pending to prevent concurrent updates and plan generation.

Enhancements:
- Add optimistic cache updates and rollback handling for Monday board column configuration mutations to keep the UI in sync and resilient to errors.


___

## **CodeAnt-AI Description**
Prevent stale plan regeneration by waiting for column updates and add optimistic column updates

### What Changed
- Column edits on Monday boards update the UI immediately (optimistic update) and automatically roll back if the server request fails.
- The import "Next" action now waits for any ongoing column update requests to finish before regenerating the plan, preventing stale or inconsistent plans.
- The "Next: Templates" button is disabled while column updates are in flight and the page shows a regenerating state during plan refresh.

### Impact
`✅ Fewer stale plans during import`
`✅ Shorter perceived edit latency for board column changes`
`✅ No accidental navigation while column updates are pending`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
