### PR TITLE
fix: classification regression — stale plan state + diagnostic logging

### DIFF
--- a/backend/src/modules/imports/monday/monday-domain-interpreter.ts
+++ b/backend/src/modules/imports/monday/monday-domain-interpreter.ts
@@ -33,6 +33,7 @@ import type {
     MondayColumnSemanticRole,
 } from './monday-config.types.js';
 import { DEFAULT_INFERENCE_HEURISTICS as heuristics } from './monday-config.types.js';
+import { logger } from '@utils/logger.js';
 
 interface InterpreterContext {
     workspace: MondayWorkspaceConfig;
@@ -126,16 +127,20 @@ export function interpretMondayData(
     }
 
     // Phase 3: Create items
+    let itemsSkippedNoBoardId = 0;
+    let itemsSkippedBoardIgnore = 0;
+    let itemsSkippedGroupIgnore = 0;
+
     for (const itemNode of itemNodes) {
         const boardId = itemNode.metadata.boardId;
-        if (!boardId) continue;
+        if (!boardId) { itemsSkippedNoBoardId++; continue; }
 
         const boardConfig = ctx.boardConfigs.get(boardId);
-        if (!boardConfig || boardConfig.role === 'ignore') continue;
+        if (!boardConfig || boardConfig.role === 'ignore') { itemsSkippedBoardIgnore++; continue; }
 
         const groupKey = `${boardId}:${itemNode.metadata.groupId}`;
         const groupConfig = ctx.groupConfigs.get(groupKey);
-        if (groupConfig?.role === 'ignore') continue;
+        if (groupConfig?.role === 'ignore') { itemsSkippedGroupIgnore++; continue; }
 
         const columnConfigMap = ctx.columnConfigs.get(boardId);
 
@@ -151,6 +156,14 @@ export function interpretMondayData(
             pendingLinks.push(...links);
         }
     }
+
+    logger.debug({
+        sessionId,
+        totalItemNodes: itemNodes.length,
+        itemsCreated: items.length,
+        skipped: { noBoardId: itemsSkippedNoBoardId, boardIgnore: itemsSkippedBoardIgnore, groupIgnore: itemsSkippedGroupIgnore },
+        containers: containers.length,
+    }, '[monday-interpreter] Phase 3 item filter results');
 
     // Phase 4: Create subitems
     for (const subitemNode of subitemNodes) {

--- a/backend/src/modules/imports/services/import-plan.service.ts
+++ b/backend/src/modules/imports/services/import-plan.service.ts
@@ -283,6 +283,20 @@ export async function generatePlanFromConnector(
         sessionId
     );
 
+    // Diagnostic: log pipeline throughput for classification debugging
+    const groupConfigSummary = workspaceConfig.boards.flatMap(b => b.groups).reduce(
+        (acc, g) => { acc[g.role] = (acc[g.role] || 0) + 1; return acc; },
+        {} as Record<string, number>
+    );
+    logger.info({
+        sessionId,
+        nodesTotal: allNodes.length,
+        nodesByType: { boards: allNodes.filter(n => n.type === 'board').length, groups: allNodes.filter(n => n.type === 'group').length, items: allNodes.filter(n => n.type === 'item').length, subitems: allNodes.filter(n => n.type === 'subitem').length },
+        planContainers: plan.containers.length,
+        planItems: plan.items.length,
+        groupConfigSummary,
+    }, '[import-plan] generatePlanFromConnector pipeline throughput');
+
     // 4. Generate classifications for Monday items (same as CSV imports)
     // This enables proper gating and schema matching for records
     const definitions = await listDefinitions({ definitionKind: 'record' });
@@ -295,6 +309,18 @@ export async function generatePlanFromConnector(
         plan.classifications = generateClassificationsForConnectorItems(plan.items, definitions);
         classificationCache.setCached(sessionId, plan.items, definitions, plan.classifications);
     }
+
+    // Diagnostic: log classification results
+    const classificationOutcomes = plan.classifications.reduce(
+        (acc, c) => { acc[c.outcome] = (acc[c.outcome] || 0) + 1; return acc; },
+        {} as Record<string, number>
+    );
+    logger.info({
+        sessionId,
+        totalClassifications: plan.classifications.length,
+        outcomes: classificationOutcomes,
+        cached: !!cachedClassifications,
+    }, '[import-plan] classification results');
 
     // Fire-and-forget vocabulary extraction from classified items
     extractAndStoreVocabulary(plan.items, plan.classifications);

--- a/frontend/src/workflows/import/wizard/MondayImportWizardView.tsx
+++ b/frontend/src/workflows/import/wizard/MondayImportWizardView.tsx
@@ -47,6 +47,14 @@ export function MondayImportWizardView({
 
     const { setImportSession: setContextImportSession } = useContextStore();
 
+    // Clear local overrides when the authoritative plan prop changes (e.g. after
+    // Step 2 regenerates the plan via generatePlan). Without this, a stale
+    // localPlanChanges from a previous ClassificationPanel save would shadow
+    // the freshly-generated plan.
+    useEffect(() => {
+        setLocalPlanChanges(null);
+    }, [plan]);
+
     // Derive effective plan from prop or local changes
     const localPlan = useMemo(() => {
         return localPlanChanges ?? plan;

--- a/frontend/src/workflows/import/wizard/steps/Step2ConfigureMapping.tsx
+++ b/frontend/src/workflows/import/wizard/steps/Step2ConfigureMapping.tsx
@@ -1260,6 +1260,21 @@ export function Step2ConfigureMapping({ onNext, onBack, session, plan, onSession
             await awaitMutation(updateGroupConfigs);
 
             const newPlan = await generatePlan.mutateAsync(session.id);
+
+            // Diagnostic: trace plan pipeline output at Step 2 boundary
+            if (import.meta.env.DEV) {
+                const outcomes = newPlan.classifications?.reduce((acc: Record<string, number>, c: any) => {
+                    acc[c.outcome] = (acc[c.outcome] || 0) + 1; return acc;
+                }, {});
+                console.debug('[Step2] handleNext plan result', {
+                    items: newPlan.items?.length ?? 0,
+                    containers: newPlan.containers?.length ?? 0,
+                    classifications: newPlan.classifications?.length ?? 0,
+                    outcomes,
+                    hasUnresolved: hasUnresolvedClassifications(newPlan),
+                });
+            }
+
             onSessionCreated(session, newPlan);
 
             // Gate advancement: if the new plan has unresolved classifications,


### PR DESCRIPTION
## **User description**
Fix stale localPlanChanges in MondayImportWizardView that shadows
freshly-generated plans after ClassificationPanel saves. Add structured
logging throughout the import pipeline (generatePlanFromConnector,
interpretMondayData item filter, Step2 handleNext) to trace item
throughput and classification outcomes at runtime.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #510** 👈
  * **PR #511**
    * **PR #512**
      * **PR #513**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Fix import plan staleness and add import diagnostics

### What Changed
- The import wizard now clears any local plan edits when the upstream plan updates so the UI shows the newly-generated plan instead of an old, overridden view.
- The import pipeline records counts and outcomes (nodes, containers, items, skipped items, classification outcomes) so operators get actionable diagnostic logs when importing Monday boards; Step 2 also emits a dev-only summary after plan regeneration.
- Item filtering now tracks why items were skipped (missing board id, board ignored, group ignored) and surfaces those counts in logs for easier troubleshooting.

### Impact
`✅ Fewer stale import views`
`✅ Clearer import diagnostics`
`✅ Fewer blocked mapping advances due to hidden stale overrides`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
