### PR TITLE
fix: show human-readable column labels in import hierarchy

### DIFF
--- a/backend/src/modules/imports/monday/monday-domain-interpreter.ts
+++ b/backend/src/modules/imports/monday/monday-domain-interpreter.ts
@@ -453,6 +453,7 @@ function convertColumnValues(
             fieldName: config?.localFieldKey ?? cv.title,
             value: extractValue(cv, semanticRole),
             renderHint: config?.renderHint ?? inferRenderHint(cv.type, semanticRole),
+            displayLabel: config?.columnTitle ?? cv.title,
         };
 
         fieldRecordings.push(recording);

--- a/backend/src/modules/imports/schema-matcher.ts
+++ b/backend/src/modules/imports/schema-matcher.ts
@@ -23,6 +23,7 @@ interface FieldRecording {
     fieldName: string;
     value: unknown;
     renderHint?: string;
+    displayLabel?: string;
 }
 
 /**
@@ -378,7 +379,7 @@ export function generateProposedDefinition(
     const fields = fieldRecordings.map((recording) => ({
         key: toFieldKey(recording.fieldName),
         type: renderHintToFieldType(recording.renderHint),
-        label: recording.fieldName,
+        label: recording.displayLabel ?? recording.fieldName,
     }));
 
     return {

--- a/backend/src/modules/imports/types.ts
+++ b/backend/src/modules/imports/types.ts
@@ -164,11 +164,13 @@ export interface ParseResult {
     }>;
 }
 
-export type FieldRecording = { 
-    fieldName: string; 
+export type FieldRecording = {
+    fieldName: string;
     value: unknown;
     /** Rendering hint for UI component selection */
     renderHint?: string;
+    /** Human-readable column label from source (e.g. Monday column title) */
+    displayLabel?: string;
     /** Pending linked item IDs from board_relation/mirror columns for post-import resolution */
     _pendingLinks?: string[];
 };

--- a/frontend/src/api/hooks/imports.ts
+++ b/frontend/src/api/hooks/imports.ts
@@ -59,6 +59,8 @@ export interface ImportPlanItem {
         value: unknown;
         /** Rendering hint for UI component (status, date, person, etc.) */
         renderHint?: string;
+        /** Human-readable column label from source (e.g. Monday column title) */
+        displayLabel?: string;
     }>;
 }
 

--- a/frontend/src/api/hooks/operations/imports.ts
+++ b/frontend/src/api/hooks/operations/imports.ts
@@ -36,6 +36,7 @@ export interface ImportPlanItem {
         fieldName: string;
         value: unknown;
         renderHint?: string;
+        displayLabel?: string;
     }>;
 }
 

--- a/frontend/src/ui/composites/DataTableImport.tsx
+++ b/frontend/src/ui/composites/DataTableImport.tsx
@@ -77,21 +77,24 @@ export interface DataTableImportProps {
  * Discover all unique fields from import plan items
  */
 export function discoverImportFields(plan: ImportPlan): ImportFieldDef[] {
-    const fieldMap = new Map<string, { count: number; renderHint?: string }>();
+    const fieldMap = new Map<string, { count: number; renderHint?: string; displayLabel?: string }>();
 
     for (const item of plan.items) {
         for (const recording of item.fieldRecordings || []) {
             const existing = fieldMap.get(recording.fieldName);
             if (existing) {
                 existing.count++;
-                // Prefer non-null renderHint
                 if (!existing.renderHint && recording.renderHint) {
                     existing.renderHint = recording.renderHint;
+                }
+                if (!existing.displayLabel && recording.displayLabel) {
+                    existing.displayLabel = recording.displayLabel;
                 }
             } else {
                 fieldMap.set(recording.fieldName, {
                     count: 1,
                     renderHint: recording.renderHint,
+                    displayLabel: recording.displayLabel,
                 });
             }
         }
@@ -103,11 +106,11 @@ export function discoverImportFields(plan: ImportPlan): ImportFieldDef[] {
             if (b[1].count !== a[1].count) return b[1].count - a[1].count;
             return a[0].localeCompare(b[0]);
         })
-        .map(([fieldName, { renderHint }]) => ({
+        .map(([fieldName, { renderHint, displayLabel }]) => ({
             fieldName,
             renderHint,
             width: getWidthForRenderHint(renderHint),
-            label: humanizeFieldName(fieldName),
+            label: displayLabel ?? humanizeFieldName(fieldName),
         }));
 }
 
@@ -115,7 +118,7 @@ export function discoverImportFields(plan: ImportPlan): ImportFieldDef[] {
  * Discover fields for a specific set of items (for nested level headers)
  */
 export function discoverFieldsForItems(items: ImportPlanItem[]): ImportFieldDef[] {
-    const fieldMap = new Map<string, { count: number; renderHint?: string }>();
+    const fieldMap = new Map<string, { count: number; renderHint?: string; displayLabel?: string }>();
 
     for (const item of items) {
         for (const recording of item.fieldRecordings || []) {
@@ -125,10 +128,14 @@ export function discoverFieldsForItems(items: ImportPlanItem[]): ImportFieldDef[
                 if (!existing.renderHint && recording.renderHint) {
                     existing.renderHint = recording.renderHint;
                 }
+                if (!existing.displayLabel && recording.displayLabel) {
+                    existing.displayLabel = recording.displayLabel;
+                }
             } else {
                 fieldMap.set(recording.fieldName, {
                     count: 1,
                     renderHint: recording.renderHint,
+                    displayLabel: recording.displayLabel,
                 });
             }
         }
@@ -139,11 +146,11 @@ export function discoverFieldsForItems(items: ImportPlanItem[]): ImportFieldDef[
             if (b[1].count !== a[1].count) return b[1].count - a[1].count;
             return a[0].localeCompare(b[0]);
         })
-        .map(([fieldName, { renderHint }]) => ({
+        .map(([fieldName, { renderHint, displayLabel }]) => ({
             fieldName,
             renderHint,
             width: getWidthForRenderHint(renderHint),
-            label: humanizeFieldName(fieldName),
+            label: displayLabel ?? humanizeFieldName(fieldName),
         }));
 }
 

--- a/frontend/src/workflows/import/components/FieldSchemaPreview.tsx
+++ b/frontend/src/workflows/import/components/FieldSchemaPreview.tsx
@@ -40,6 +40,7 @@ interface FieldSchemaPreviewProps {
 interface FieldRow {
     id: string;
     fieldName: string;
+    displayLabel?: string;
     value: unknown;
     renderHint?: string;
     matchedType?: string;
@@ -81,6 +82,7 @@ export function FieldSchemaPreview({ item, schemaMatch, compact = false }: Field
             return {
                 id: `${idx}`,
                 fieldName: fr.fieldName,
+                displayLabel: fr.displayLabel,
                 value: fr.value,
                 renderHint: fr.renderHint,
                 matchedType: matchedField?.type,
@@ -98,7 +100,7 @@ export function FieldSchemaPreview({ item, schemaMatch, compact = false }: Field
             width: 120,
             renderCell: (row: FieldRow) => (
                 <div className="flex items-center gap-1.5">
-                    <span className="font-medium text-ws-text-secondary">{row.fieldName}</span>
+                    <span className="font-medium text-ws-text-secondary">{row.displayLabel ?? row.fieldName}</span>
                     {row.renderHint && (
                         <span className="text-[10px] font-mono text-ws-muted bg-slate-100 px-1 rounded">
                             {row.renderHint}

--- a/frontend/src/workflows/import/components/TablePreview.tsx
+++ b/frontend/src/workflows/import/components/TablePreview.tsx
@@ -25,21 +25,24 @@ interface TablePreviewProps {
 export function TablePreview({ plan, selectedRecordId, onSelect }: TablePreviewProps) {
     // Collect all unique field names from all items
     const columns = useMemo(() => {
-        const fieldSet = new Map<string, string>(); // fieldName -> renderHint
+        const fieldSet = new Map<string, { renderHint: string; displayLabel?: string }>();
 
         for (const item of plan.items) {
             if (!item.fieldRecordings) continue;
             for (const fr of item.fieldRecordings) {
                 if (!fieldSet.has(fr.fieldName)) {
-                    fieldSet.set(fr.fieldName, fr.renderHint || 'text');
+                    fieldSet.set(fr.fieldName, {
+                        renderHint: fr.renderHint || 'text',
+                        displayLabel: fr.displayLabel,
+                    });
                 }
             }
         }
 
-        return Array.from(fieldSet.entries()).map(([name, hint]) => ({
+        return Array.from(fieldSet.entries()).map(([name, { renderHint, displayLabel }]) => ({
             key: name,
-            label: humanizeFieldName(name),
-            renderHint: hint as DataFieldKind,
+            label: displayLabel ?? humanizeFieldName(name),
+            renderHint: renderHint as DataFieldKind,
         }));
     }, [plan.items]);
 

--- a/shared/src/schemas/imports.ts
+++ b/shared/src/schemas/imports.ts
@@ -20,6 +20,8 @@ export const FieldRecordingSchema = z.object({
     fieldName: z.string(),
     value: z.unknown(),
     renderHint: z.string().optional(),
+    /** Human-readable column label from source (e.g. Monday column title) */
+    displayLabel: z.string().optional(),
 });
 
 export const InterpretationOutputSchema = z.object({


### PR DESCRIPTION
## **User description**
Add displayLabel to FieldRecording (shared schema, backend type,
frontend type). Populate from Monday column title in convertColumnValues.
Use displayLabel in schema-matcher proposed definitions, DataTableImport
field discovery, TablePreview column headers, and FieldSchemaPreview
field names. Falls back to humanizeFieldName when displayLabel is absent.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #510**
  * **PR #511** 👈
    * **PR #512**
      * **PR #513**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Show source column titles as human-readable labels in import preview and matching

### What Changed
- Import field recordings now carry a display label taken from the source (e.g., Monday column title) and that label is shown instead of raw field keys in table previews and field lists
- Schema-matcher proposed definitions and discovered import fields use the source display label when available, falling back to a humanized field name only if the source label is absent
- Column headers and field preview views present the original column titles, improving clarity when mapping and reviewing imported data

### Impact
`✅ Clearer import column headers`
`✅ More accurate schema suggestions during import`
`✅ Fewer mis-mapped or ambiguous fields`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
