### PR TITLE
fix: add step indicator and escape hatch to import sidebar

### DIFF
--- a/frontend/src/ui/panels/ImportPanel.tsx
+++ b/frontend/src/ui/panels/ImportPanel.tsx
@@ -32,6 +32,9 @@ export function ImportPanel() {
     const [sourceType, setSourceType] = useState<ImportSourceType>('file');
     const prevSessionIdRef = useRef<string | null>(null);
 
+    // Wizard step state — lifted here so the sidebar can display progress
+    const [wizardStep, setWizardStep] = useState(1);
+
     // Use uiStore for session/plan (aliased for compatibility with child components)
     const session = importSession;
     const plan = importPlan;
@@ -57,6 +60,7 @@ export function ImportPanel() {
         setImportSession(null);
         setImportPlan(null);
         clearSelection();
+        setWizardStep(1);
     }, [setImportSession, setImportPlan, clearSelection]);
 
     // Auto-switch source type based on session connector type (only when session changes)
@@ -96,6 +100,8 @@ export function ImportPanel() {
                         onSelectItem={selectImportItem}
                         onReset={handleReset}
                         onSessionCreated={handleSessionCreated}
+                        currentStep={wizardStep}
+                        onStepChange={setWizardStep}
                     />
                 );
             case 'file':
@@ -123,6 +129,10 @@ export function ImportPanel() {
                     plan={plan}
                     onSessionCreated={handleSessionCreated}
                     onReset={handleReset}
+                    currentStep={wizardStep}
+                    totalSteps={6}
+                    onBack={wizardStep > 1 ? () => setWizardStep(s => s - 1) : undefined}
+                    onCancel={handleReset}
                 />
                 <ResizeHandle direction="right" onResize={handleSidebarResize} />
 

--- a/frontend/src/workflows/import/panels/ImportSidebar.tsx
+++ b/frontend/src/workflows/import/panels/ImportSidebar.tsx
@@ -19,6 +19,8 @@ import {
     Check,
     RefreshCw,
     Globe,
+    ArrowLeft,
+    X,
 } from 'lucide-react';
 import { useRef, useCallback, useState } from 'react';
 
@@ -48,6 +50,11 @@ interface ImportSidebarProps {
     plan: ImportPlan | null;
     onSessionCreated: (session: ImportSession, plan: ImportPlan) => void;
     onReset: () => void;
+    /** Wizard step tracking (from ImportPanel) */
+    currentStep?: number;
+    totalSteps?: number;
+    onBack?: () => void;
+    onCancel?: () => void;
 }
 
 // ============================================================================
@@ -92,7 +99,7 @@ function SourceIcon({ id: _id, icon, label, isActive, isConnected, isDisabled, o
 // COMPONENT
 // ============================================================================
 
-export function ImportSidebar({ width, sourceType, onSourceChange, session, onSessionCreated, onReset }: ImportSidebarProps) {
+export function ImportSidebar({ width, sourceType, onSourceChange, session, onSessionCreated, onReset, currentStep, totalSteps, onBack, onCancel }: ImportSidebarProps) {
     // State (sourceType is now controlled by parent)
     const [rawData, setRawData] = useState('');
     const [parserName, setParserName] = useState('monday');
@@ -157,7 +164,7 @@ export function ImportSidebar({ width, sourceType, onSourceChange, session, onSe
         setError(null);
     }, [onReset]);
 
-    // If session exists, show session info and reset button
+    // If session exists, show session info, step progress, and navigation
     if (session) {
         return (
             <aside style={{ width }} className="shrink-0 border-r border-ws-panel-border bg-ws-panel-bg flex flex-col">
@@ -173,11 +180,42 @@ export function ImportSidebar({ width, sourceType, onSourceChange, session, onSe
                         </div>
                     </div>
 
+                    {/* Step Indicator */}
+                    {currentStep != null && totalSteps != null && (
+                        <div className="p-4 border-b border-ws-panel-border">
+                            <div className="text-xs font-medium text-ws-text-secondary mb-2">
+                                Step {currentStep} of {totalSteps}
+                            </div>
+                            <div className="w-full h-1.5 bg-slate-200 rounded-full overflow-hidden">
+                                <div
+                                    className="h-full bg-blue-500 rounded-full transition-all duration-300"
+                                    style={{ width: `${(currentStep / totalSteps) * 100}%` }}
+                                />
+                            </div>
+                        </div>
+                    )}
+
                     {/* Spacer */}
                     <div className="flex-1" />
 
-                    {/* Reset Button */}
-                    <div className="p-4 border-t border-ws-panel-border">
+                    {/* Navigation Buttons */}
+                    <div className="p-4 border-t border-ws-panel-border flex flex-col gap-2">
+                        {onBack && (
+                            <button
+                                onClick={onBack}
+                                className="w-full flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium text-ws-text-secondary bg-slate-100 hover:bg-slate-200 rounded-lg transition-colors"
+                            >
+                                <ArrowLeft className="w-4 h-4" />
+                                Back
+                            </button>
+                        )}
+                        <button
+                            onClick={onCancel ?? handleReset}
+                            className="w-full flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium text-red-600 bg-red-50 hover:bg-red-100 rounded-lg transition-colors"
+                        >
+                            <X className="w-4 h-4" />
+                            Cancel Import
+                        </button>
                         <button
                             onClick={handleReset}
                             className="w-full flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium text-ws-text-secondary bg-slate-100 hover:bg-slate-200 rounded-lg transition-colors"

--- a/frontend/src/workflows/import/wizard/MondayImportWizardView.tsx
+++ b/frontend/src/workflows/import/wizard/MondayImportWizardView.tsx
@@ -22,6 +22,9 @@ interface MondayImportWizardViewProps {
     onSelectItem: (item: any) => void;
     onReset: () => void;
     onSessionCreated: (session: ImportSession, plan: ImportPlan) => void;
+    /** Controlled step (lifted to ImportPanel for sidebar sync) */
+    currentStep?: number;
+    onStepChange?: (step: number) => void;
 }
 
 const STEPS = [
@@ -39,8 +42,17 @@ export function MondayImportWizardView({
     onSelectItem,
     onReset,
     onSessionCreated,
+    currentStep: controlledStep,
+    onStepChange,
 }: MondayImportWizardViewProps) {
-    const [currentStep, setCurrentStep] = useState(1);
+    // Support both controlled (from ImportPanel) and uncontrolled step
+    const [internalStep, setInternalStep] = useState(1);
+    const currentStep = controlledStep ?? internalStep;
+    const setCurrentStep = useCallback((update: number | ((s: number) => number)) => {
+        const next = typeof update === 'function' ? update(currentStep) : update;
+        if (onStepChange) onStepChange(next);
+        else setInternalStep(next);
+    }, [currentStep, onStepChange]);
     const [localPlanChanges, setLocalPlanChanges] = useState<ImportPlan | null>(null);
     const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
     const [inspectorTab, setInspectorTab] = useState('import_details');


### PR DESCRIPTION
## **User description**
Lift wizard step state to ImportPanel so the sidebar can display
progress. Add step indicator (progress bar + "Step N of M"), Back
button (visible on step 2+), and Cancel Import button to the
ImportSidebar session view. MondayImportWizardView now accepts
optional controlled step props while remaining backward-compatible.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #510**
  * **PR #511**
    * **PR #512** 👈
      * **PR #513**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Show import progress and add Back/Cancel controls in the import sidebar

### What Changed
- The import sidebar now displays the current wizard step and a progress bar ("Step N of M") when an import session is active.
- Added Back and Cancel Import buttons to the sidebar; Back is enabled when on step 2 or later, and Cancel stops the session from the sidebar.
- Wizard step state is lifted so the center wizard view and sidebar stay in sync; resetting an import now returns the wizard to step 1.

### Impact
`✅ Clearer import progress`
`✅ Easier step navigation during imports`
`✅ Ability to cancel an import from the sidebar`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
