### PR TITLE
fix: make import tab always visible in panel registry

### DIFF
--- a/frontend/src/workspace/panelRegistry.ts
+++ b/frontend/src/workspace/panelRegistry.ts
@@ -214,7 +214,7 @@ export const PANEL_DEFINITIONS: Record<PanelId, PanelDefinition> = {
         icon: FolderOpen, // Will need import
         permanent: false,
         defaultPlacement: { area: 'center' },
-        shouldShow: (ctx) => ctx.importSession.sessionId !== null,
+        shouldShow: () => true,
         canActOn: () => true,
     },
     'export-workbench': {


### PR DESCRIPTION
## **User description**
Change import-workbench shouldShow predicate from session-dependent
to always-true so the tab is accessible without an active session.
Previously required an active import session, hiding the entry point
in the Dockview overflow menu.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #510**
  * **PR #511**
    * **PR #512**
      * **PR #513** 👈

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->

## Summary by Sourcery

Enhancements:
- Relax visibility conditions for the import workbench panel so it no longer depends on an active import session.


___

## **CodeAnt-AI Description**
Show Import tab in panel menu even without an active import session

### What Changed
- The Import workbench tab is now always visible in the panel registry and Dockview overflow menu, even when no import session is active
- Users can open the Import panel directly without first creating or restoring an import session

### Impact
`✅ Easier access to Import tab`
`✅ Fewer hidden entry points in the panel menu`
`✅ Shorter workflow to start an import`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
