### PR TITLE
feat: add React dashboard renderer for Electron

### DIFF
--- a/apps/autohelper-electron/src/renderer/App.tsx
+++ b/apps/autohelper-electron/src/renderer/App.tsx
@@ -1,0 +1,28 @@
+import { ServiceStatus } from "./components/ServiceStatus";
+import { SettingsForm } from "./components/SettingsForm";
+import { ContactSync } from "./components/ContactSync";
+import { Pairing } from "./components/Pairing";
+import { Toast } from "./components/Toast";
+import { useToast } from "./hooks/useToast";
+import { useConfig } from "./hooks/useConfig";
+
+export function App() {
+  const { toasts, success, error } = useToast();
+  const { config, saveSection } = useConfig();
+
+  return (
+    <>
+      <div className="dashboard">
+        <h1>AutoHelper</h1>
+        <p className="subtitle">Local service configuration</p>
+
+        <ServiceStatus />
+        <SettingsForm onError={error} onSuccess={success} />
+        <ContactSync onError={error} onSuccess={success} />
+        <Pairing config={config} onConfigUpdate={saveSection} onError={error} onSuccess={success} />
+      </div>
+
+      <Toast toasts={toasts} />
+    </>
+  );
+}

--- a/apps/autohelper-electron/src/renderer/api.ts
+++ b/apps/autohelper-electron/src/renderer/api.ts
@@ -1,0 +1,49 @@
+/* API client for AutoHelper backend */
+
+const API_BASE = "http://127.0.0.1:8100";
+
+class ApiError extends Error {
+  constructor(
+    message: string,
+    public status: number,
+    public path: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+async function request<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+  headers?: Record<string, string>,
+): Promise<T> {
+  const opts: RequestInit = {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+  };
+
+  if (body !== undefined) {
+    opts.body = JSON.stringify(body);
+  }
+
+  const res = await fetch(API_BASE + path, opts);
+
+  if (!res.ok) {
+    throw new ApiError(`${method} ${path}: ${res.status}`, res.status, path);
+  }
+
+  return res.json();
+}
+
+export const api = {
+  get: <T>(path: string) => request<T>("GET", path),
+  put: <T>(path: string, body: unknown) => request<T>("PUT", path, body),
+  post: <T>(path: string, body: unknown) => request<T>("POST", path, body),
+  del: <T>(path: string, headers?: Record<string, string>) =>
+    request<T>("DELETE", path, undefined, headers),
+};

--- a/apps/autohelper-electron/src/renderer/components/ContactSync.tsx
+++ b/apps/autohelper-electron/src/renderer/components/ContactSync.tsx
@@ -1,0 +1,114 @@
+import { StatusRow } from "./StatusRow";
+import { useContacts } from "../hooks/useContacts";
+
+function formatTime(iso: string | null): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  return d.toLocaleString();
+}
+
+interface ContactSyncProps {
+  onError: (message: string) => void;
+  onSuccess: (message: string) => void;
+}
+
+export function ContactSync({ onError, onSuccess }: ContactSyncProps) {
+  const { status, history, loading, syncing, triggerSync } = useContacts();
+
+  const handleSync = async () => {
+    try {
+      await triggerSync();
+      onSuccess("Contact sync triggered");
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  if (loading) {
+    return (
+      <section>
+        <h2>Contact Sync Status</h2>
+        <div className="section-body">
+          <StatusRow label="Loading..." value="" status="ok" />
+        </div>
+      </section>
+    );
+  }
+
+  if (!status) {
+    return (
+      <section>
+        <h2>Contact Sync Status</h2>
+        <div className="section-body">
+          <div className="status-row">
+            <span className="label">Status</span>
+            <span className="value empty">Module not available</span>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <>
+      <section>
+        <h2>Contact Sync Status</h2>
+        <div className="section-body">
+          <StatusRow
+            label="Enabled"
+            value={status.enabled ? "Yes" : "No"}
+            status={status.enabled ? "ok" : "warn"}
+          />
+          <StatusRow label="Last Sync" value={formatTime(status.last_sync)} status="ok" />
+          <StatusRow label="Next Sync" value={formatTime(status.next_sync)} status="ok" />
+          <StatusRow
+            label="Last Result"
+            value={status.last_status || "—"}
+            status={status.last_status === "failed" ? "error" : "ok"}
+          />
+          <div className="button-row">
+            <button onClick={handleSync} disabled={syncing}>
+              {syncing ? "Syncing..." : "Sync Now"}
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2>Sync History</h2>
+        <div className="section-body">
+          <table className="log-table">
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Status</th>
+                <th>Created</th>
+                <th>Updated</th>
+                <th>Deleted</th>
+              </tr>
+            </thead>
+            <tbody>
+              {!history || history.entries.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="empty">
+                    No sync history
+                  </td>
+                </tr>
+              ) : (
+                history.entries.map((entry, idx) => (
+                  <tr key={idx}>
+                    <td>{formatTime(entry.started_at)}</td>
+                    <td>{entry.status}</td>
+                    <td>{entry.created ?? 0}</td>
+                    <td>{entry.updated ?? 0}</td>
+                    <td>{entry.deleted ?? 0}</td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/apps/autohelper-electron/src/renderer/components/Pairing.tsx
+++ b/apps/autohelper-electron/src/renderer/components/Pairing.tsx
@@ -1,0 +1,96 @@
+import { useState } from "react";
+import { usePairing } from "../hooks/usePairing";
+import type { ConfigValues } from "../types";
+
+interface PairingProps {
+  config: ConfigValues | null;
+  onConfigUpdate: (values: ConfigValues) => Promise<void>;
+  onError: (message: string) => void;
+  onSuccess: (message: string) => void;
+}
+
+export function Pairing({ config, onConfigUpdate, onError, onSuccess }: PairingProps) {
+  const { paired, pairing, unpairing, pair, unpair } = usePairing(config, onConfigUpdate);
+  const [showCodeInput, setShowCodeInput] = useState(false);
+  const [code, setCode] = useState("");
+
+  const hasFrontend = !!(config?.autoart_frontend_url || config?.autoart_api_url);
+
+  const handlePair = async () => {
+    if (code.length !== 6) {
+      onError("Code must be 6 characters");
+      return;
+    }
+
+    try {
+      await pair(code);
+      onSuccess("Paired successfully");
+      setShowCodeInput(false);
+      setCode("");
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const handleUnpair = async () => {
+    if (!confirm("Unpair from AutoArt backend?")) return;
+
+    try {
+      await unpair();
+      onSuccess("Unpaired");
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  return (
+    <section>
+      <h2>Pairing</h2>
+      <div className="section-body">
+        <div className="status-row">
+          <span className="label">
+            <span className={`status-dot ${paired ? "ok" : "warn"}`} />
+            Status
+          </span>
+          <span className="value">{paired ? "Paired" : "Not paired"}</span>
+        </div>
+
+        {showCodeInput && !paired && (
+          <div className="field" style={{ marginTop: "12px" }}>
+            <label htmlFor="pairing-code">Pairing Code</label>
+            <input
+              type="text"
+              id="pairing-code"
+              maxLength={6}
+              value={code}
+              onChange={(e) => setCode(e.target.value.toUpperCase())}
+              placeholder="6-character code"
+              style={{ width: "200px" }}
+            />
+          </div>
+        )}
+
+        <div className="button-row">
+          {!paired && hasFrontend && !showCodeInput && (
+            <button onClick={() => setShowCodeInput(true)}>Pair with AutoArt</button>
+          )}
+
+          {showCodeInput && !paired && (
+            <>
+              <button onClick={handlePair} disabled={pairing || code.length !== 6} className="primary">
+                {pairing ? "Pairing..." : "Submit"}
+              </button>
+              <button onClick={() => setShowCodeInput(false)}>Cancel</button>
+            </>
+          )}
+
+          {paired && (
+            <button onClick={handleUnpair} disabled={unpairing} className="danger">
+              {unpairing ? "Unpairing..." : "Unpair"}
+            </button>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/autohelper-electron/src/renderer/components/ServiceStatus.tsx
+++ b/apps/autohelper-electron/src/renderer/components/ServiceStatus.tsx
@@ -1,0 +1,31 @@
+import { StatusRow } from "./StatusRow";
+import { useHealth } from "../hooks/useHealth";
+
+export function ServiceStatus() {
+  const { data, loading } = useHealth();
+
+  if (loading) {
+    return (
+      <section>
+        <h2>Service Status</h2>
+        <div className="section-body">
+          <StatusRow label="Loading..." value="" status="ok" />
+        </div>
+      </section>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <section>
+      <h2>Service Status</h2>
+      <div className="section-body">
+        <StatusRow label="Service" value={data.service.message} status={data.service.status} />
+        <StatusRow label="Database" value={data.database.message} status={data.database.status} />
+        <StatusRow label="Migrations" value={data.migrations.message} status={data.migrations.status} />
+        <StatusRow label="Uptime" value={data.uptime.message} status={data.uptime.status} />
+      </div>
+    </section>
+  );
+}

--- a/apps/autohelper-electron/src/renderer/components/SettingsField.tsx
+++ b/apps/autohelper-electron/src/renderer/components/SettingsField.tsx
@@ -1,0 +1,144 @@
+import { useState, useEffect } from "react";
+import type { SchemaField } from "../types";
+
+interface SettingsFieldProps {
+  field: SchemaField;
+  value: unknown;
+  onChange: (key: string, value: unknown) => void;
+  dependsOnValue?: boolean;
+}
+
+export function SettingsField({ field, value, onChange, dependsOnValue }: SettingsFieldProps) {
+  const [localValue, setLocalValue] = useState(value);
+
+  useEffect(() => {
+    setLocalValue(value);
+  }, [value]);
+
+  const handleChange = (newValue: unknown) => {
+    setLocalValue(newValue);
+    onChange(field.key, newValue);
+  };
+
+  // Handle depends_on visibility
+  if (field.depends_on && !dependsOnValue) {
+    return null;
+  }
+
+  if (field.type === "bool") {
+    return (
+      <div className="toggle">
+        <input
+          type="checkbox"
+          id={`cfg-${field.key}`}
+          checked={!!localValue}
+          onChange={(e) => handleChange(e.target.checked)}
+        />
+        <label htmlFor={`cfg-${field.key}`}>{field.label}</label>
+      </div>
+    );
+  }
+
+  return (
+    <div className="field">
+      <label htmlFor={`cfg-${field.key}`}>{field.label}</label>
+      {renderInput()}
+    </div>
+  );
+
+  function renderInput() {
+    switch (field.type) {
+      case "int":
+        return (
+          <input
+            type="number"
+            id={`cfg-${field.key}`}
+            value={localValue as number ?? field.default ?? ""}
+            onChange={(e) => handleChange(parseInt(e.target.value, 10))}
+            min={field.min}
+            max={field.max}
+          />
+        );
+
+      case "select":
+        return (
+          <select
+            id={`cfg-${field.key}`}
+            value={(localValue as string) ?? field.default ?? ""}
+            onChange={(e) => handleChange(e.target.value)}
+          >
+            {field.options?.map((opt) => (
+              <option key={opt} value={opt}>
+                {opt}
+              </option>
+            ))}
+          </select>
+        );
+
+      case "string_list":
+        return (
+          <textarea
+            id={`cfg-${field.key}`}
+            rows={3}
+            value={
+              Array.isArray(localValue)
+                ? (localValue as string[]).join("\n")
+                : (localValue as string) || ""
+            }
+            onChange={(e) => {
+              const lines = e.target.value
+                .split("\n")
+                .map((s) => s.trim())
+                .filter(Boolean);
+              handleChange(lines);
+            }}
+            placeholder={field.placeholder}
+          />
+        );
+
+      case "tag_list":
+        return (
+          <input
+            type="text"
+            id={`cfg-${field.key}`}
+            value={
+              Array.isArray(localValue)
+                ? (localValue as string[]).join(", ")
+                : (localValue as string) || ""
+            }
+            onChange={(e) => {
+              const tags = e.target.value
+                .split(",")
+                .map((s) => s.trim())
+                .filter(Boolean);
+              handleChange(tags);
+            }}
+            placeholder={field.placeholder}
+          />
+        );
+
+      case "text":
+        return (
+          <textarea
+            id={`cfg-${field.key}`}
+            rows={4}
+            value={(localValue as string) ?? field.default ?? ""}
+            onChange={(e) => handleChange(e.target.value)}
+            placeholder={field.placeholder}
+          />
+        );
+
+      default:
+        // "string"
+        return (
+          <input
+            type="text"
+            id={`cfg-${field.key}`}
+            value={(localValue as string) ?? field.default ?? ""}
+            onChange={(e) => handleChange(e.target.value.trim())}
+            placeholder={field.placeholder}
+          />
+        );
+    }
+  }
+}

--- a/apps/autohelper-electron/src/renderer/components/SettingsForm.tsx
+++ b/apps/autohelper-electron/src/renderer/components/SettingsForm.tsx
@@ -1,0 +1,46 @@
+import { SettingsSection } from "./SettingsSection";
+import { useConfig } from "../hooks/useConfig";
+import type { ConfigValues } from "../types";
+
+interface SettingsFormProps {
+  onError: (message: string) => void;
+  onSuccess: (message: string) => void;
+}
+
+export function SettingsForm({ onError, onSuccess }: SettingsFormProps) {
+  const { schema, config, loading, saveSection } = useConfig();
+
+  if (loading) {
+    return (
+      <section>
+        <h2>Settings</h2>
+        <div className="section-body">
+          <p>Loading...</p>
+        </div>
+      </section>
+    );
+  }
+
+  if (!schema || !config) {
+    return null;
+  }
+
+  const handleSave = async (values: ConfigValues) => {
+    await saveSection(values);
+  };
+
+  return (
+    <>
+      {schema.sections.map((section, idx) => (
+        <SettingsSection
+          key={idx}
+          section={section}
+          config={config}
+          onSave={handleSave}
+          onError={onError}
+          onSuccess={onSuccess}
+        />
+      ))}
+    </>
+  );
+}

--- a/apps/autohelper-electron/src/renderer/components/SettingsSection.tsx
+++ b/apps/autohelper-electron/src/renderer/components/SettingsSection.tsx
@@ -1,0 +1,112 @@
+import { useState, useMemo } from "react";
+import { SettingsField } from "./SettingsField";
+import type { SchemaSection, ConfigValues } from "../types";
+
+interface SettingsSectionProps {
+  section: SchemaSection;
+  config: ConfigValues;
+  onSave: (values: ConfigValues) => Promise<void>;
+  onError: (message: string) => void;
+  onSuccess: (message: string) => void;
+}
+
+export function SettingsSection({ section, config, onSave, onError, onSuccess }: SettingsSectionProps) {
+  const [values, setValues] = useState<ConfigValues>(() => {
+    const initial: ConfigValues = {};
+    for (const field of section.fields) {
+      initial[field.key] = config[field.key] ?? field.default;
+    }
+    return initial;
+  });
+
+  const [saving, setSaving] = useState(false);
+
+  // Track dependency values for depends_on
+  const dependencyValues = useMemo(() => {
+    const deps: Record<string, boolean> = {};
+    for (const field of section.fields) {
+      if (field.type === "bool") {
+        deps[field.key] = !!values[field.key];
+      }
+    }
+    return deps;
+  }, [section.fields, values]);
+
+  const handleFieldChange = (key: string, value: unknown) => {
+    setValues((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await onSave(values);
+      onSuccess(`${section.label} saved`);
+    } catch (e) {
+      onError(`Failed to save ${section.label.toLowerCase()}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Group fields by row_group
+  const fieldGroups: Array<{ isRow: boolean; fields: typeof section.fields }> = [];
+  const processed = new Set<string>();
+
+  for (const field of section.fields) {
+    if (processed.has(field.key)) continue;
+
+    if (field.row_group) {
+      const group = section.fields.filter((f) => f.row_group === field.row_group);
+      fieldGroups.push({ isRow: true, fields: group });
+      group.forEach((f) => processed.add(f.key));
+    } else {
+      fieldGroups.push({ isRow: false, fields: [field] });
+      processed.add(field.key);
+    }
+  }
+
+  return (
+    <section className={section.admin_only ? "admin-only" : ""}>
+      <h2>
+        {section.label}
+        {section.admin_only && <span className="admin-badge">Admin</span>}
+      </h2>
+      <div className="section-body">
+        {fieldGroups.map((group, idx) => {
+          if (group.isRow) {
+            return (
+              <div key={idx} className="field-row">
+                {group.fields.map((field) => (
+                  <SettingsField
+                    key={field.key}
+                    field={field}
+                    value={values[field.key]}
+                    onChange={handleFieldChange}
+                    dependsOnValue={field.depends_on ? dependencyValues[field.depends_on] : true}
+                  />
+                ))}
+              </div>
+            );
+          }
+
+          const field = group.fields[0];
+          return (
+            <SettingsField
+              key={field.key}
+              field={field}
+              value={values[field.key]}
+              onChange={handleFieldChange}
+              dependsOnValue={field.depends_on ? dependencyValues[field.depends_on] : true}
+            />
+          );
+        })}
+
+        <div className="button-row">
+          <button onClick={handleSave} disabled={saving} className="primary">
+            {saving ? "Saving..." : "Save"}
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/autohelper-electron/src/renderer/components/StatusRow.tsx
+++ b/apps/autohelper-electron/src/renderer/components/StatusRow.tsx
@@ -1,0 +1,17 @@
+interface StatusRowProps {
+  label: string;
+  value: string;
+  status: "ok" | "warn" | "error";
+}
+
+export function StatusRow({ label, value, status }: StatusRowProps) {
+  return (
+    <div className="status-row">
+      <span className="label">
+        <span className={`status-dot ${status}`} />
+        {label}
+      </span>
+      <span className="value">{value}</span>
+    </div>
+  );
+}

--- a/apps/autohelper-electron/src/renderer/components/Toast.tsx
+++ b/apps/autohelper-electron/src/renderer/components/Toast.tsx
@@ -1,0 +1,19 @@
+import type { Toast as ToastType } from "../hooks/useToast";
+
+interface ToastProps {
+  toasts: ToastType[];
+}
+
+export function Toast({ toasts }: ToastProps) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="toast-container">
+      {toasts.map((toast) => (
+        <div key={toast.id} className={`toast visible ${toast.type}`}>
+          {toast.message}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/autohelper-electron/src/renderer/hooks/useConfig.ts
+++ b/apps/autohelper-electron/src/renderer/hooks/useConfig.ts
@@ -1,0 +1,61 @@
+import { useState, useEffect, useCallback } from "react";
+import { api } from "../api";
+import type { ConfigSchema, ConfigValues } from "../types";
+
+interface UseConfigResult {
+  schema: ConfigSchema | null;
+  config: ConfigValues | null;
+  loading: boolean;
+  error: Error | null;
+  saving: boolean;
+  saveSection: (values: ConfigValues) => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+export function useConfig(): UseConfigResult {
+  const [schema, setSchema] = useState<ConfigSchema | null>(null);
+  const [config, setConfig] = useState<ConfigValues | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const fetchConfig = useCallback(async () => {
+    try {
+      const [schemaData, configData] = await Promise.all([
+        api.get<ConfigSchema>("/config/schema"),
+        api.get<ConfigValues>("/config"),
+      ]);
+      setSchema(schemaData);
+      setConfig(configData);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error(String(e)));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const saveSection = useCallback(async (values: ConfigValues) => {
+    setSaving(true);
+    try {
+      const updated = await api.put<ConfigValues>("/config", values);
+      setConfig(updated);
+    } finally {
+      setSaving(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchConfig();
+  }, [fetchConfig]);
+
+  return {
+    schema,
+    config,
+    loading,
+    error,
+    saving,
+    saveSection,
+    refresh: fetchConfig,
+  };
+}

--- a/apps/autohelper-electron/src/renderer/hooks/useContacts.ts
+++ b/apps/autohelper-electron/src/renderer/hooks/useContacts.ts
@@ -1,0 +1,65 @@
+import { useState, useEffect, useCallback } from "react";
+import { api } from "../api";
+import type { ContactStatus, ContactHistory, SyncResult } from "../types";
+
+interface UseContactsResult {
+  status: ContactStatus | null;
+  history: ContactHistory | null;
+  loading: boolean;
+  error: Error | null;
+  syncing: boolean;
+  triggerSync: () => Promise<void>;
+  refresh: () => Promise<void>;
+}
+
+export function useContacts(pollInterval = 30000): UseContactsResult {
+  const [status, setStatus] = useState<ContactStatus | null>(null);
+  const [history, setHistory] = useState<ContactHistory | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [syncing, setSyncing] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [statusData, historyData] = await Promise.all([
+        api.get<ContactStatus>("/contacts/status"),
+        api.get<ContactHistory>("/contacts/history"),
+      ]);
+      setStatus(statusData);
+      setHistory(historyData);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error(String(e)));
+      setStatus(null);
+      setHistory(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const triggerSync = useCallback(async () => {
+    setSyncing(true);
+    try {
+      await api.post<SyncResult>("/contacts/sync", {});
+      await fetchData();
+    } finally {
+      setSyncing(false);
+    }
+  }, [fetchData]);
+
+  useEffect(() => {
+    fetchData();
+    const interval = setInterval(fetchData, pollInterval);
+    return () => clearInterval(interval);
+  }, [fetchData, pollInterval]);
+
+  return {
+    status,
+    history,
+    loading,
+    error,
+    syncing,
+    triggerSync,
+    refresh: fetchData,
+  };
+}

--- a/apps/autohelper-electron/src/renderer/hooks/useHealth.ts
+++ b/apps/autohelper-electron/src/renderer/hooks/useHealth.ts
@@ -1,0 +1,72 @@
+import { useState, useEffect, useCallback } from "react";
+import { api } from "../api";
+import type { HealthResponse, StatusResponse } from "../types";
+
+interface CombinedStatus {
+  service: { status: "ok" | "error"; message: string };
+  database: { status: "ok" | "error"; message: string };
+  migrations: { status: "ok"; message: string };
+  uptime: { status: "ok"; message: string };
+}
+
+interface UseHealthResult {
+  data: CombinedStatus | null;
+  loading: boolean;
+  error: Error | null;
+  refresh: () => Promise<void>;
+}
+
+export function useHealth(pollInterval = 30000): UseHealthResult {
+  const [data, setData] = useState<CombinedStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchHealth = useCallback(async () => {
+    try {
+      const [health, status] = await Promise.all([
+        api.get<HealthResponse>("/health"),
+        api.get<StatusResponse>("/status"),
+      ]);
+
+      const combined: CombinedStatus = {
+        service: {
+          status: health.status === "ok" ? "ok" : "error",
+          message: health.status === "ok" ? "Running" : "Error",
+        },
+        database: {
+          status: status.database?.accessible ? "ok" : "error",
+          message: status.database?.accessible ? "Connected" : "Unreachable",
+        },
+        migrations: {
+          status: "ok",
+          message: `${status.database?.migration_count ?? 0} applied`,
+        },
+        uptime: {
+          status: "ok",
+          message: health.uptime || "—",
+        },
+      };
+
+      setData(combined);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error(String(e)));
+      setData({
+        service: { status: "error", message: "Unreachable" },
+        database: { status: "error", message: "Unreachable" },
+        migrations: { status: "ok", message: "—" },
+        uptime: { status: "ok", message: "—" },
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchHealth();
+    const interval = setInterval(fetchHealth, pollInterval);
+    return () => clearInterval(interval);
+  }, [fetchHealth, pollInterval]);
+
+  return { data, loading, error, refresh: fetchHealth };
+}

--- a/apps/autohelper-electron/src/renderer/hooks/usePairing.ts
+++ b/apps/autohelper-electron/src/renderer/hooks/usePairing.ts
@@ -1,0 +1,74 @@
+import { useState, useCallback, useMemo } from "react";
+import type { ConfigValues } from "../types";
+
+interface PairResponse {
+  key: string;
+}
+
+interface UsePairingResult {
+  paired: boolean;
+  pairing: boolean;
+  unpairing: boolean;
+  pair: (code: string) => Promise<void>;
+  unpair: () => Promise<void>;
+}
+
+export function usePairing(config: ConfigValues | null, onConfigUpdate: (values: ConfigValues) => Promise<void>): UsePairingResult {
+  const [pairing, setPairing] = useState(false);
+  const [unpairing, setUnpairing] = useState(false);
+
+  const paired = useMemo(() => {
+    return !!config?.autoart_link_key;
+  }, [config]);
+
+  const pair = useCallback(
+    async (code: string) => {
+      if (!config) return;
+
+      setPairing(true);
+      try {
+        const apiUrl = (config.autoart_api_url as string) || "http://localhost:3001";
+        const res = await fetch(apiUrl + "/api/pair/redeem", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ code: code.trim() }),
+        });
+
+        if (!res.ok) throw new Error("Invalid code or expired");
+
+        const data: PairResponse = await res.json();
+        await onConfigUpdate({ autoart_link_key: data.key });
+      } finally {
+        setPairing(false);
+      }
+    },
+    [config, onConfigUpdate],
+  );
+
+  const unpair = useCallback(async () => {
+    if (!config) return;
+
+    setUnpairing(true);
+    try {
+      const apiUrl = (config.autoart_api_url as string) || "http://localhost:3001";
+      const key = config.autoart_link_key as string;
+
+      if (key) {
+        // Best-effort notification to backend
+        fetch(apiUrl + "/api/autohelper/unpair", {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+            "x-autohelper-key": key,
+          },
+        }).catch(() => {});
+      }
+
+      await onConfigUpdate({ autoart_link_key: "" });
+    } finally {
+      setUnpairing(false);
+    }
+  }, [config, onConfigUpdate]);
+
+  return { paired, pairing, unpairing, pair, unpair };
+}

--- a/apps/autohelper-electron/src/renderer/hooks/useToast.tsx
+++ b/apps/autohelper-electron/src/renderer/hooks/useToast.tsx
@@ -1,0 +1,29 @@
+import { useState, useCallback } from "react";
+
+export type ToastType = "success" | "error";
+
+export interface Toast {
+  id: number;
+  message: string;
+  type: ToastType;
+}
+
+let nextId = 1;
+
+export function useToast() {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const show = useCallback((message: string, type: ToastType) => {
+    const id = nextId++;
+    setToasts((prev) => [...prev, { id, message, type }]);
+
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 3000);
+  }, []);
+
+  const success = useCallback((message: string) => show(message, "success"), [show]);
+  const error = useCallback((message: string) => show(message, "error"), [show]);
+
+  return { toasts, success, error };
+}

--- a/apps/autohelper-electron/src/renderer/index.html
+++ b/apps/autohelper-electron/src/renderer/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AutoHelper</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/main.tsx"></script>
+</body>
+</html>

--- a/apps/autohelper-electron/src/renderer/main.tsx
+++ b/apps/autohelper-electron/src/renderer/main.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { App } from "./App";
+import "./styles/dashboard.css";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Root element not found");
+
+ReactDOM.createRoot(root).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/apps/autohelper-electron/src/renderer/styles/dashboard.css
+++ b/apps/autohelper-electron/src/renderer/styles/dashboard.css
@@ -1,0 +1,337 @@
+/* AutoHelper Dashboard — follows AutoArt design palette (DESIGN.md) */
+
+:root {
+  /* Foundation Neutrals */
+  --bg: #F5F2ED;
+  --bg-surface: #EDEAE4;
+  --border: #D6D2CB;
+  --fg: #2E2E2C;
+  --fg-secondary: #5A5A57;
+  --fg-disabled: #8C8C88;
+
+  /* Structural Accents */
+  --accent: #3F5C6E;
+  --accent-fg: #FFFFFF;
+  --accent-secondary: #8A5A3C;
+
+  /* System Feedback */
+  --color-success: #6F7F5C;
+  --color-warning: #B89B5E;
+  --color-error: #8C4A4A;
+
+  /* Mono */
+  --mono-fg: #3A3A38;
+  --mono-bg: rgba(63, 92, 110, 0.035);
+
+  /* Typography */
+  --font-serif: "Source Serif 4", "Georgia", serif;
+  --font-sans: "Source Sans 3", "Segoe UI", sans-serif;
+  --font-mono: "IBM Plex Mono", monospace;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-serif);
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--fg);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+.dashboard {
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 32px 24px;
+}
+
+h1 {
+  font-size: 20px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.subtitle {
+  font-size: 12px;
+  color: var(--fg-secondary);
+  margin-bottom: 24px;
+}
+
+/* Sections */
+section {
+  margin-bottom: 24px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+}
+
+section h2 {
+  font-size: 16px;
+  font-weight: 600;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+}
+
+.section-body {
+  padding: 16px;
+}
+
+/* Form rows */
+.field {
+  margin-bottom: 12px;
+}
+
+.field:last-child {
+  margin-bottom: 0;
+}
+
+.field label {
+  display: block;
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--fg-secondary);
+  margin-bottom: 4px;
+  font-family: var(--font-sans);
+}
+
+.field input[type="text"],
+.field input[type="number"],
+.field input[type="password"],
+.field select,
+.field textarea {
+  width: 100%;
+  padding: 6px 8px;
+  font-size: 14px;
+  font-family: var(--font-serif);
+  color: var(--fg);
+  background: #FFFFFF;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  outline: none;
+}
+
+.field input:focus,
+.field select:focus,
+.field textarea:focus {
+  border-color: var(--accent);
+}
+
+.field textarea {
+  resize: vertical;
+  min-height: 60px;
+}
+
+.field-row {
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+  margin-bottom: 12px;
+}
+
+.field-row .field {
+  flex: 1;
+  margin-bottom: 0;
+}
+
+/* Checkbox toggle */
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.toggle input[type="checkbox"] {
+  accent-color: var(--accent);
+  width: 16px;
+  height: 16px;
+}
+
+.toggle label {
+  font-size: 14px;
+  font-family: var(--font-sans);
+  color: var(--fg);
+  cursor: pointer;
+}
+
+/* Buttons */
+button {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  padding: 6px 14px;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  background: var(--bg-surface);
+  color: var(--fg);
+  cursor: pointer;
+}
+
+button:hover {
+  background: var(--border);
+}
+
+button.primary {
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-color: var(--accent);
+}
+
+button.primary:hover {
+  opacity: 0.9;
+}
+
+button.danger {
+  color: var(--color-error);
+  border-color: var(--color-error);
+}
+
+button.danger:hover {
+  background: var(--color-error);
+  color: var(--accent-fg);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.button-row {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+/* Status indicators */
+.status-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+
+.status-row:last-child {
+  border-bottom: none;
+}
+
+.status-row .label {
+  color: var(--fg-secondary);
+  font-family: var(--font-sans);
+}
+
+.status-row .value {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--mono-fg);
+  font-feature-settings: "liga" 0;
+}
+
+.status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
+.status-dot.ok {
+  background: var(--color-success);
+}
+.status-dot.warn {
+  background: var(--color-warning);
+}
+.status-dot.error {
+  background: var(--color-error);
+}
+
+/* Log table */
+.log-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.log-table th {
+  text-align: left;
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--fg-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.log-table td {
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--mono-fg);
+  font-feature-settings: "liga" 0;
+}
+
+/* Toast / messages */
+.toast-container {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 100;
+}
+
+.toast {
+  padding: 8px 14px;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  border-radius: 2px;
+  opacity: 0;
+  transition: opacity 160ms ease-out;
+  pointer-events: none;
+}
+
+.toast.visible {
+  opacity: 1;
+}
+
+.toast.success {
+  background: var(--color-success);
+  color: #FFFFFF;
+}
+
+.toast.error {
+  background: var(--color-error);
+  color: #FFFFFF;
+}
+
+/* Admin badge */
+.admin-badge {
+  display: inline-block;
+  font-family: var(--font-sans);
+  font-size: 10px;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent-secondary);
+  border: 1px solid var(--accent-secondary);
+  border-radius: 2px;
+  padding: 1px 5px;
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
+/* Empty state */
+.empty {
+  font-size: 13px;
+  color: var(--fg-disabled);
+  font-style: italic;
+}

--- a/apps/autohelper-electron/src/renderer/tsconfig.json
+++ b/apps/autohelper-electron/src/renderer/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["./**/*.ts", "./**/*.tsx"],
+  "exclude": ["vite.config.ts"]
+}

--- a/apps/autohelper-electron/src/renderer/tsconfig.node.json
+++ b/apps/autohelper-electron/src/renderer/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/autohelper-electron/src/renderer/types.ts
+++ b/apps/autohelper-electron/src/renderer/types.ts
@@ -1,0 +1,70 @@
+/* Type definitions for AutoHelper API responses */
+
+export interface HealthResponse {
+  status: "ok" | "error";
+  uptime?: string;
+}
+
+export interface StatusResponse {
+  database?: {
+    accessible: boolean;
+    migration_count: number;
+  };
+}
+
+export type FieldType =
+  | "bool"
+  | "int"
+  | "string"
+  | "select"
+  | "string_list"
+  | "tag_list"
+  | "text";
+
+export interface SchemaField {
+  key: string;
+  label: string;
+  type: FieldType;
+  default?: unknown;
+  min?: number;
+  max?: number;
+  options?: string[];
+  placeholder?: string;
+  row_group?: string;
+  depends_on?: string;
+}
+
+export interface SchemaSection {
+  label: string;
+  admin_only?: boolean;
+  fields: SchemaField[];
+}
+
+export interface ConfigSchema {
+  sections: SchemaSection[];
+}
+
+export type ConfigValues = Record<string, unknown>;
+
+export interface ContactStatus {
+  enabled: boolean;
+  last_sync: string | null;
+  next_sync: string | null;
+  last_status: string | null;
+}
+
+export interface ContactHistoryEntry {
+  started_at: string;
+  status: string;
+  created?: number;
+  updated?: number;
+  deleted?: number;
+}
+
+export interface ContactHistory {
+  entries: ContactHistoryEntry[];
+}
+
+export interface SyncResult {
+  message: string;
+}

--- a/apps/autohelper-electron/src/renderer/vite.config.ts
+++ b/apps/autohelper-electron/src/renderer/vite.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  root: __dirname,
+  base: './',
+  build: {
+    outDir: '../../dist/renderer',
+    emptyOutDir: true,
+  },
+  server: {
+    port: 5174,
+    proxy: {
+      '/health': 'http://127.0.0.1:8100',
+      '/status': 'http://127.0.0.1:8100',
+      '/config': 'http://127.0.0.1:8100',
+      '/contacts': 'http://127.0.0.1:8100',
+      '/api': 'http://127.0.0.1:8100',
+    },
+  },
+});


### PR DESCRIPTION
## **User description**
Settings form, service status, contact sync, pairing UI, and toast
notifications. Vite dev server on :5174 with proxy to Python backend.
Hooks for health polling, config, contacts, and pairing state.


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #514**
  * **PR #515** 👈
    * **PR #516**
      * **PR #517**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->


___

## **CodeAnt-AI Description**
Add React dashboard renderer for Electron

### What Changed
- Adds a local AutoHelper dashboard UI that connects to the local backend (default 127.0.0.1:8100) and displays service health and uptime.
- Provides a settings UI where configuration sections and fields (booleans, numbers, selects, text, lists, tags) can be viewed and saved, including grouped rows and dependency-based visibility.
- Adds contact sync status and history, with a "Sync Now" action and polling for updates.
- Adds pairing controls to enter a 6-character code to pair/unpair with the AutoArt backend and persist the link key in configuration.
- Shows temporary toast notifications for success and error messages.
- Includes a Vite dev server setup (port 5174) with proxy routes to the backend for local development.

### Impact
`✅ Clearer service status and uptime`
`✅ Can trigger and view contact sync history`
`✅ Shorter pairing and configuration workflow`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
