### PR TITLE
feat: add POST /shutdown endpoint for graceful Python backend stop

### DIFF
--- a/apps/autohelper/autohelper/modules/health/router.py
+++ b/apps/autohelper/autohelper/modules/health/router.py
@@ -1,8 +1,11 @@
 """Health module routes."""
 
+import os
+import signal
+
 from fastapi import APIRouter
 
-from .schemas import HealthResponse, StatusResponse
+from .schemas import HealthResponse, ShutdownResponse, StatusResponse
 from .service import HealthService
 
 router = APIRouter()
@@ -32,3 +35,17 @@ async def status() -> StatusResponse:
     """
     service = HealthService()
     return service.get_status()
+
+
+@router.post("/shutdown", response_model=ShutdownResponse)
+async def shutdown() -> ShutdownResponse:
+    """
+    Gracefully shut down the server.
+
+    Sends SIGINT to the current process, which uvicorn handles as a clean
+    shutdown (runs lifespan teardown, closes connections).
+
+    Used by the Electron shell to stop the Python backend before exit.
+    """
+    os.kill(os.getpid(), signal.SIGINT)
+    return ShutdownResponse(status="shutting_down")

--- a/apps/autohelper/autohelper/modules/health/schemas.py
+++ b/apps/autohelper/autohelper/modules/health/schemas.py
@@ -13,6 +13,12 @@ class HealthResponse(BaseModel):
     version: str
 
 
+class ShutdownResponse(BaseModel):
+    """Shutdown request acknowledgement."""
+
+    status: str
+
+
 class RootStatus(BaseModel):
     """Status of a configured root."""
 


### PR DESCRIPTION
## **User description**
Sends SIGINT to the current process, triggering uvicorn's clean
shutdown (lifespan teardown, connection close). Used by Electron's
python-manager to stop the backend before exit. Adds ShutdownResponse
schema.


<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #514**
  * **PR #515**
    * **PR #516** 👈
      * **PR #517**

This tree was auto-generated by [Stackit](https://github.com/getstackit/stackit)
<!-- STACKIT-SECTION-END -->

## Summary by Sourcery

Add an HTTP endpoint to gracefully shut down the Python backend service.

New Features:
- Expose a POST /shutdown health route that triggers a graceful server shutdown and returns a structured response.

Enhancements:
- Introduce a ShutdownResponse schema to standardize acknowledgements for shutdown requests.


___

## **CodeAnt-AI Description**
**Add POST /shutdown endpoint to trigger graceful server shutdown**

### What Changed
- Exposes POST /shutdown that requests the Python backend to stop by sending SIGINT to the process
- The server begins a clean shutdown (runs lifespan teardown and closes connections) when the endpoint is called
- The endpoint returns a simple structured acknowledgement: {"status":"shutting_down"}
- Adds a ShutdownResponse schema for the shutdown acknowledgement; intended for use by the Electron shell's python-manager to stop the backend before exit

### Impact
`✅ Cleaner app exit from Electron`
`✅ Graceful server shutdown with connection teardown`
`✅ Predictable shutdown acknowledgement returned to callers`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
